### PR TITLE
Make client interface internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - **Breaking:** Various endpoint clients with child endpoint clients and/or extra parameters have had their virtual property setters removed; you can still override the property for customization however
   (reason: it's discouraged to call virtual methods or set virtual properties from a constructor in a non-sealed class)
 - **Breaking:** `IGuildIdLogClient.ParamSince` and its implementation `GuildIdLogClient.ParamSince` are no longer virtual and no longer have a public setter to follow convention of e.g. `CreateSubtokenClient` (use `IGuildIdLogClient.Since(int? since)` to set this parameter with the fluent design pattern)
+- **Breaking:** Since the settings in `IConnection` are read-only and are only used interally, the `.Connection` property of `IGw2WebApiClient`, `IGw2WebApiV2Client` and all endpoint clients have been either removed or are now marked as internal
+  (if you still want to keep track of these settings, you should keep a reference to the instance yourself now)
 
 ## 0.3.1
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@
 - **Breaking:** Various endpoint clients with child endpoint clients and/or extra parameters have had their virtual property setters removed; you can still override the property for customization however
   (reason: it's discouraged to call virtual methods or set virtual properties from a constructor in a non-sealed class)
 - **Breaking:** `IGuildIdLogClient.ParamSince` and its implementation `GuildIdLogClient.ParamSince` are no longer virtual and no longer have a public setter to follow convention of e.g. `CreateSubtokenClient` (use `IGuildIdLogClient.Since(int? since)` to set this parameter with the fluent design pattern)
-- **Breaking:** Since the settings in `IConnection` are read-only and are only used interally, the `.Connection` property of `IGw2WebApiClient`, `IGw2WebApiV2Client` and all endpoint clients have been either removed or are now marked as internal
-  (if you still want to keep track of these settings, you should keep a reference to the instance yourself now)
+- **Breaking:** Since the settings in `IConnection` are only used interally, the `.Connection` property of `IGw2WebApiClient`, `IGw2WebApiV2Client` and all endpoint clients have been either removed or are now marked as internal
+  (if you still want to keep track of these settings, you should keep a reference to the instance yourself)
+- Most `Connection` properties have a public setter to allow changes after object creation
 
 ## 0.3.1
 ### Fixes

--- a/Gw2Sharp.Tests/WebApi/Gw2WebApiClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Gw2WebApiClientTests.cs
@@ -1,4 +1,4 @@
-﻿using Gw2Sharp.WebApi;
+using Gw2Sharp.WebApi;
 using Gw2Sharp.WebApi.V2;
 using NSubstitute;
 using Xunit;
@@ -15,10 +15,8 @@ namespace Gw2Sharp.Tests.WebApi
             var client1 = new Gw2WebApiClient();
             var client2 = new Gw2WebApiClient(connection);
 
-            Assert.IsType<Connection>(client1.Connection);
             Assert.IsType<Gw2WebApiV2Client>(client1.V2);
 
-            Assert.Same(connection, client2.Connection);
             Assert.IsType<Gw2WebApiV2Client>(client2.V2);
         }
     }

--- a/Gw2Sharp.Tests/WebApi/Gw2WebApiClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Gw2WebApiClientTests.cs
@@ -17,6 +17,7 @@ namespace Gw2Sharp.Tests.WebApi
 
             Assert.IsType<Gw2WebApiV2Client>(client1.V2);
 
+            Assert.Same(connection, ((IWebApiClientInternal)client2.V2.Account.Achievements).Connection);
             Assert.IsType<Gw2WebApiV2Client>(client2.V2);
         }
     }

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
@@ -51,7 +51,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var (data, expected) = this.GetTestData(file);
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            this.Client.Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, "?page=2&page_size=100");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -68,7 +68,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             where TObject : IApiV2Object
         {
             var (data, expected) = this.GetTestData(file);
-            this.Client.Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, string.Empty);
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -88,7 +88,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var id = this.GetId<TId>(expected[idName]);
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            this.Client.Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, $"/{id.ToString()}");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -105,7 +105,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             where TObject : IApiV2Object
         {
             var (data, expected) = this.GetTestData(file);
-            this.Client.Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, "?ids=all");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -128,7 +128,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             }));
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            this.Client.Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, $"?ids={string.Join(",", ids.Select(i => i?.ToString()))}");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -147,7 +147,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var (data, expected) = this.GetTestData(file);
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            this.Client.Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, string.Empty);
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -188,14 +188,14 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             Assert.Equal(uri, callInfo.ArgAt<IHttpRequest>(0).Url);
             var requestHeaders = callInfo.ArgAt<IHttpRequest>(0).RequestHeaders;
             Assert.Contains(new KeyValuePair<string, string>("Accept", "application/json"), requestHeaders);
-            Assert.Contains(new KeyValuePair<string, string>("User-Agent", client.Connection.UserAgent), requestHeaders);
+            Assert.Contains(new KeyValuePair<string, string>("User-Agent", ((IClientInternal)client).Connection.UserAgent), requestHeaders);
         }
 
         protected virtual void AssertAuthenticatedRequest(CallInfo callInfo, IEndpointClient client)
         {
             var requestHeaders = callInfo.ArgAt<IHttpRequest>(0).RequestHeaders;
             if (client.IsAuthenticated)
-                Assert.Contains(new KeyValuePair<string, string>("Authorization", $"Bearer {client.Connection.AccessToken}"), requestHeaders);
+                Assert.Contains(new KeyValuePair<string, string>("Authorization", $"Bearer {((IClientInternal)client).Connection.AccessToken}"), requestHeaders);
             else
                 Assert.DoesNotContain(requestHeaders, h => h.Key == "Authorization");
         }
@@ -203,7 +203,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
         protected virtual void AssertLocalizedRequest(CallInfo callInfo, IEndpointClient client)
         {
             var requestHeaders = callInfo.ArgAt<IHttpRequest>(0).RequestHeaders;
-            Assert.Contains(new KeyValuePair<string, string>("Accept-Language", client.Connection.LocaleString), requestHeaders);
+            Assert.Contains(new KeyValuePair<string, string>("Accept-Language", ((IClientInternal)client).Connection.LocaleString), requestHeaders);
         }
 
         protected virtual void AssertSchemaVersionRequest(CallInfo callInfo, IEndpointClient client)

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
@@ -51,7 +51,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var (data, expected) = this.GetTestData(file);
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IWebApiClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, "?page=2&page_size=100");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -68,7 +68,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             where TObject : IApiV2Object
         {
             var (data, expected) = this.GetTestData(file);
-            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IWebApiClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, string.Empty);
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -88,7 +88,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var id = this.GetId<TId>(expected[idName]);
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IWebApiClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, $"/{id.ToString()}");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -105,7 +105,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             where TObject : IApiV2Object
         {
             var (data, expected) = this.GetTestData(file);
-            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IWebApiClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, "?ids=all");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -128,7 +128,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             }));
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IWebApiClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, $"?ids={string.Join(",", ids.Select(i => i?.ToString()))}");
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -147,7 +147,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var (data, expected) = this.GetTestData(file);
 
             var httpRequest = Substitute.For<IHttpRequest>();
-            ((IClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
+            ((IWebApiClientInternal)this.Client).Connection.HttpClient.RequestAsync(Arg.Any<IHttpRequest>(), CancellationToken.None).Returns(callInfo =>
             {
                 this.AssertRequest(callInfo, client, string.Empty);
                 this.AssertAuthenticatedRequest(callInfo, client);
@@ -188,14 +188,14 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             Assert.Equal(uri, callInfo.ArgAt<IHttpRequest>(0).Url);
             var requestHeaders = callInfo.ArgAt<IHttpRequest>(0).RequestHeaders;
             Assert.Contains(new KeyValuePair<string, string>("Accept", "application/json"), requestHeaders);
-            Assert.Contains(new KeyValuePair<string, string>("User-Agent", ((IClientInternal)client).Connection.UserAgent), requestHeaders);
+            Assert.Contains(new KeyValuePair<string, string>("User-Agent", ((IWebApiClientInternal)client).Connection.UserAgent), requestHeaders);
         }
 
         protected virtual void AssertAuthenticatedRequest(CallInfo callInfo, IEndpointClient client)
         {
             var requestHeaders = callInfo.ArgAt<IHttpRequest>(0).RequestHeaders;
             if (client.IsAuthenticated)
-                Assert.Contains(new KeyValuePair<string, string>("Authorization", $"Bearer {((IClientInternal)client).Connection.AccessToken}"), requestHeaders);
+                Assert.Contains(new KeyValuePair<string, string>("Authorization", $"Bearer {((IWebApiClientInternal)client).Connection.AccessToken}"), requestHeaders);
             else
                 Assert.DoesNotContain(requestHeaders, h => h.Key == "Authorization");
         }
@@ -203,7 +203,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
         protected virtual void AssertLocalizedRequest(CallInfo callInfo, IEndpointClient client)
         {
             var requestHeaders = callInfo.ArgAt<IHttpRequest>(0).RequestHeaders;
-            Assert.Contains(new KeyValuePair<string, string>("Accept-Language", ((IClientInternal)client).Connection.LocaleString), requestHeaders);
+            Assert.Contains(new KeyValuePair<string, string>("Accept-Language", ((IWebApiClientInternal)client).Connection.LocaleString), requestHeaders);
         }
 
         protected virtual void AssertSchemaVersionRequest(CallInfo callInfo, IEndpointClient client)

--- a/Gw2Sharp/WebApi/Connection.cs
+++ b/Gw2Sharp/WebApi/Connection.cs
@@ -113,10 +113,10 @@ namespace Gw2Sharp.WebApi
         }
 
         /// <inheritdoc />
-        public string AccessToken { get; private set; }
+        public string AccessToken { get; set; }
 
         /// <inheritdoc />
-        public Locale Locale { get; private set; }
+        public Locale Locale { get; set; }
 
         /// <inheritdoc />
         public string LocaleString
@@ -136,10 +136,10 @@ namespace Gw2Sharp.WebApi
         public string UserAgent { get; private set; }
 
         /// <inheritdoc />
-        public IHttpClient HttpClient { get; private set; }
+        public IHttpClient HttpClient { get; set; }
 
         /// <inheritdoc />
-        public ICacheMethod CacheMethod { get; private set; }
+        public ICacheMethod CacheMethod { get; set; }
 
 
         /// <inheritdoc />

--- a/Gw2Sharp/WebApi/Gw2WebApiClient.cs
+++ b/Gw2Sharp/WebApi/Gw2WebApiClient.cs
@@ -6,7 +6,7 @@ namespace Gw2Sharp.WebApi
     /// <summary>
     /// A client for the Guild Wars 2 web API.
     /// </summary>
-    public class Gw2WebApiClient : IGw2WebApiClient, IWebApiClientInternal
+    public class Gw2WebApiClient : IGw2WebApiClient
     {
         /// <summary>
         /// The base URL for making Guild Wars 2 API requests.
@@ -24,19 +24,14 @@ namespace Gw2Sharp.WebApi
         /// Creates a new <see cref="Gw2WebApiClient"/>.
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
+        /// <exception cref="NullReferenceException"><paramref name="connection"/> is <c>null</c>.</exception>
         public Gw2WebApiClient(IConnection connection)
         {
-            this.Connection = connection;
+            if (connection == null)
+                throw new ArgumentNullException(nameof(connection));
+
             this.v2 = new Gw2WebApiV2Client(connection);
         }
-
-        /// <inheritdoc />
-        IConnection IWebApiClientInternal.Connection => this.Connection;
-
-        /// <summary>
-        /// Provides the client connection to make web requests.
-        /// </summary>
-        internal IConnection Connection { get; }
 
         /// <inheritdoc />
         public virtual IGw2WebApiV2Client V2 => this.v2;

--- a/Gw2Sharp/WebApi/Gw2WebApiClient.cs
+++ b/Gw2Sharp/WebApi/Gw2WebApiClient.cs
@@ -6,7 +6,7 @@ namespace Gw2Sharp.WebApi
     /// <summary>
     /// A client for the Guild Wars 2 web API.
     /// </summary>
-    public class Gw2WebApiClient : IGw2WebApiClient
+    public class Gw2WebApiClient : IGw2WebApiClient, IWebApiClientInternal
     {
         /// <summary>
         /// The base URL for making Guild Wars 2 API requests.
@@ -31,7 +31,12 @@ namespace Gw2Sharp.WebApi
         }
 
         /// <inheritdoc />
-        public IConnection Connection { get; private set; }
+        IConnection IWebApiClientInternal.Connection => this.Connection;
+
+        /// <summary>
+        /// Provides the client connection to make web requests.
+        /// </summary>
+        internal IConnection Connection { get; }
 
         /// <inheritdoc />
         public virtual IGw2WebApiV2Client V2 => this.v2;

--- a/Gw2Sharp/WebApi/IGw2WebApiClient.cs
+++ b/Gw2Sharp/WebApi/IGw2WebApiClient.cs
@@ -8,11 +8,6 @@ namespace Gw2Sharp.WebApi
     public interface IGw2WebApiClient
     {
         /// <summary>
-        /// Provides the client connection to make web requests.
-        /// </summary>
-        IConnection Connection { get; }
-
-        /// <summary>
         /// Gets the version 2 of the API.
         /// </summary>
         IGw2WebApiV2Client V2 { get; }

--- a/Gw2Sharp/WebApi/IWebApiClientInternal.cs
+++ b/Gw2Sharp/WebApi/IWebApiClientInternal.cs
@@ -1,9 +1,9 @@
-namespace Gw2Sharp.WebApi.V2.Clients
+namespace Gw2Sharp.WebApi
 {
     /// <summary>
-    /// Implements a client, consumed internally.
+    /// Implements a web API client, consumed internally.
     /// </summary>
-    internal interface IClientInternal
+    internal interface IWebApiClientInternal
     {
         /// <summary>
         /// Gets the client connection to make web requests.

--- a/Gw2Sharp/WebApi/V2/Clients/BaseClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseClient.cs
@@ -5,7 +5,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// <summary>
     /// An abstract base class for implementing clients.
     /// </summary>
-    public abstract class BaseClient : IClient
+    public abstract class BaseClient : IClient, IClientInternal
     {
         /// <summary>
         /// Creates a new base client.
@@ -18,6 +18,11 @@ namespace Gw2Sharp.WebApi.V2.Clients
         }
 
         /// <inheritdoc />
-        public IConnection Connection { get; private set; }
+        IConnection IClientInternal.Connection => this.Connection;
+
+        /// <summary>
+        /// Gets the client connection to make web requests.
+        /// </summary>
+        internal IConnection Connection { get; }
     }
 }

--- a/Gw2Sharp/WebApi/V2/Clients/BaseClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseClient.cs
@@ -5,7 +5,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// <summary>
     /// An abstract base class for implementing clients.
     /// </summary>
-    public abstract class BaseClient : IClient, IClientInternal
+    public abstract class BaseClient : IClient, IWebApiClientInternal
     {
         /// <summary>
         /// Creates a new base client.
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         }
 
         /// <inheritdoc />
-        IConnection IClientInternal.Connection => this.Connection;
+        IConnection IWebApiClientInternal.Connection => this.Connection;
 
         /// <summary>
         /// Gets the client connection to make web requests.

--- a/Gw2Sharp/WebApi/V2/Clients/IClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/IClient.cs
@@ -5,12 +5,5 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// </summary>
     public interface IClient
     {
-        /// <summary>
-        /// Provides the client connection to make web requests.
-        /// </summary>
-        /// <value>
-        /// The client connection.
-        /// </value>
-        IConnection Connection { get; }
     }
 }

--- a/Gw2Sharp/WebApi/V2/Clients/IClientInternal.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/IClientInternal.cs
@@ -1,0 +1,13 @@
+namespace Gw2Sharp.WebApi.V2.Clients
+{
+    /// <summary>
+    /// Implements a client, consumed internally.
+    /// </summary>
+    internal interface IClientInternal
+    {
+        /// <summary>
+        /// Gets the client connection to make web requests.
+        /// </summary>
+        IConnection Connection { get; }
+    }
+}

--- a/Gw2Sharp/WebApi/V2/Gw2WebApiV2Client.cs
+++ b/Gw2Sharp/WebApi/V2/Gw2WebApiV2Client.cs
@@ -56,7 +56,9 @@ namespace Gw2Sharp.WebApi.V2
         /// <exception cref="NullReferenceException"><paramref name="connection"/> is <c>null</c>.</exception>
         public Gw2WebApiV2Client(IConnection connection)
         {
-            this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            if (connection == null)
+                throw new ArgumentNullException(nameof(connection));
+
             this.account = new AccountClient(connection);
             this.achievements = new AchievementsClient(connection);
             this.backstory = new BackstoryClient(connection);
@@ -88,9 +90,6 @@ namespace Gw2Sharp.WebApi.V2
             this.tokenInfo = new TokenInfoClient(connection);
             this.worldBosses = new WorldBossesClient(connection);
         }
-
-        /// <inheritdoc />
-        public IConnection Connection { get; private set; }
 
         /// <inheritdoc />
         public virtual IAccountClient Account => this.account;

--- a/Gw2Sharp/WebApi/V2/IGw2WebApiV2Client.cs
+++ b/Gw2Sharp/WebApi/V2/IGw2WebApiV2Client.cs
@@ -8,11 +8,6 @@ namespace Gw2Sharp.WebApi.V2
     public interface IGw2WebApiV2Client
     {
         /// <summary>
-        /// Provides the client connection to make web requests.
-        /// </summary>
-        IConnection Connection { get; }
-
-        /// <summary>
         /// Gets the account information.
         /// Requires scopes: account.
         /// </summary>


### PR DESCRIPTION
It should only be used internally for the various endpoint clients. Consumers have nothing to gain from having it exposed.