### PR TITLE
Improve ApiEnum and ApiFlags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Gw2Sharp History
 
+## 0.6.1
+### Endpoints
+- Change property `Emblem` in `Gw2Sharp.WebApi.V2.Models.Guild` to be nullable because the API might leave this property out ([#10](https://github.com/Archomeda/Gw2Sharp/issues/10))
+
+### Fixes
+- Fix default instantiations of `ApiEnum` and `ApiFlags` that might cause `InvalidCastException`s when requesting data by removing the non-generic `ApiEnum` and `ApiFlags` variants (they were only used internally for easy casting when deserializing) ([#10](https://github.com/Archomeda/Gw2Sharp/issues/10))
+
 ## 0.6.0
 ### Endpoints
 - **Breaking:** `Gw2Sharp.WebApi.V2.Models.GuildTeam` has had the type of its property `Ladders` changed from `PvpStatsLadders` to `IReadOnlyDictionary<string, PvpStatsAggregate>`

--- a/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
+++ b/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
@@ -138,6 +138,7 @@
     <None Remove="TestFiles\Gliders\Gliders.single.json" />
     <None Remove="TestFiles\Guild\GuildId.1.json" />
     <None Remove="TestFiles\Guild\GuildId.2.json" />
+    <None Remove="TestFiles\Guild\GuildId.3.json" />
     <None Remove="TestFiles\Guild\GuildIdLog.json" />
     <None Remove="TestFiles\Guild\GuildIdMembers.json" />
     <None Remove="TestFiles\Guild\GuildIdRanks.json" />
@@ -369,6 +370,7 @@
     <EmbeddedResource Include="TestFiles\Gliders\Gliders.single.json" />
     <EmbeddedResource Include="TestFiles\Guild\GuildId.1.json" />
     <EmbeddedResource Include="TestFiles\Guild\GuildId.2.json" />
+    <EmbeddedResource Include="TestFiles\Guild\GuildId.3.json" />
     <EmbeddedResource Include="TestFiles\Guild\GuildIdLog.json" />
     <EmbeddedResource Include="TestFiles\Guild\GuildIdMembers.json" />
     <EmbeddedResource Include="TestFiles\Guild\GuildIdRanks.json" />

--- a/Gw2Sharp.Tests/Json/Converters/ApiEnumConverterTests.cs
+++ b/Gw2Sharp.Tests/Json/Converters/ApiEnumConverterTests.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.Tests.Json.Converters
         public void CanConvertTest()
         {
             var converter = new ApiEnumConverter();
-            Assert.True(converter.CanConvert(typeof(ApiEnum)));
+            Assert.True(converter.CanConvert(typeof(ApiEnum<>)));
         }
     }
 }

--- a/Gw2Sharp.Tests/TestFiles/Guild/GuildId.3.json
+++ b/Gw2Sharp.Tests/TestFiles/Guild/GuildId.3.json
@@ -1,0 +1,5 @@
+{
+  "id": "12345678-90AB-CDEF-FEDC-BA0987654321",
+  "name": "abc",
+  "tag": "ABC"
+}

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/Guild/GuildIdClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/Guild/GuildIdClientTests.cs
@@ -14,6 +14,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
         [Theory]
         [InlineData("TestFiles.Guild.GuildId.1.json")]
         [InlineData("TestFiles.Guild.GuildId.2.json")]
+        [InlineData("TestFiles.Guild.GuildId.3.json")]
         public Task BlobTest(string file) => this.AssertBlobDataAsync(this.Client, file);
     }
 }

--- a/Gw2Sharp.Tests/WebApi/V2/Models/ApiEnumTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Models/ApiEnumTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel;
-using Gw2Sharp.Tests.Helpers;
 using Gw2Sharp.WebApi.V2.Models;
 using Newtonsoft.Json;
 using Xunit;
@@ -83,6 +81,14 @@ namespace Gw2Sharp.Tests.WebApi.V2.Models
         }
 
         [Fact]
+        public void ImplicitConversionFromStringTest()
+        {
+            var expected = new ApiEnum<TestEnum>(TestEnum.EnumValue2);
+            ApiEnum<TestEnum> actual = "EnumValue2";
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void ImplicitConversionToStringTest()
         {
             string expected = "SomeRawEnumValue";
@@ -160,20 +166,5 @@ namespace Gw2Sharp.Tests.WebApi.V2.Models
 #pragma warning restore CS0253 // Possible unintended reference comparison; right hand side needs cast
             Assert.True(item1 != null!);
         }
-
-        #region ArgumentNullException tests
-
-        [Fact]
-        public void ArgumentNullConstructorTest()
-        {
-            AssertArguments.ThrowsWhenNull(
-                () => new ApiEnum<Enum>(TestEnum.EnumValue1),
-                new[] { true });
-            AssertArguments.ThrowsWhenNull(
-                () => new ApiEnum<Enum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()),
-                new[] { true, false });
-        }
-
-        #endregion
     }
 }

--- a/Gw2Sharp.Tests/WebApi/V2/Models/ApiEnumTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Models/ApiEnumTests.cs
@@ -35,12 +35,19 @@ namespace Gw2Sharp.Tests.WebApi.V2.Models
         [Theory]
         [InlineData("{\"Enum\":\"EnumValue2\"}", "EnumValue2", TestEnum.EnumValue2)]
         [InlineData("{\"Enum\":\"SomeRandomValue\"}", "SomeRandomValue", TestEnum.EnumValue3)]
-        [InlineData("{\"Enum\":undefined}", "EnumValue3", TestEnum.EnumValue3)]
-        public void DeserializeTest(string json, string expectedRaw, TestEnum expected)
+        [InlineData("{\"Enum\":\"\"}", "", TestEnum.EnumValue3)]
+        [InlineData("{\"Enum\":undefined}", null, TestEnum.EnumValue3)]
+        [InlineData("{}", null, null)]
+        public void DeserializeTest(string json, string expectedRaw, TestEnum? expected)
         {
             var obj = JsonConvert.DeserializeObject<JsonObject>(json);
-            Assert.Equal(expectedRaw, obj.Enum.RawValue);
-            Assert.Equal(expected, obj.Enum.Value);
+            if (expected == null)
+                Assert.Null(obj.Enum);
+            else
+            {
+                Assert.Equal(expectedRaw, obj.Enum.RawValue);
+                Assert.Equal(expected, obj.Enum.Value);
+            }
         }
 
         [Fact]
@@ -94,66 +101,64 @@ namespace Gw2Sharp.Tests.WebApi.V2.Models
         [Fact]
         public void EqualsTest()
         {
-            var item = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
             var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
-            Assert.True(item.Equals(item2));
+            Assert.True(item1.Equals(item2));
         }
 
         [Fact]
         public void NotEqualsTest()
         {
-            var item = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
             var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue2.ToString());
             var item3 = new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString());
-            Assert.False(item.Equals(item2));
-            Assert.False(item.Equals(item3));
+            Assert.False(item1.Equals(item2));
+            Assert.False(item1.Equals(item3));
             Assert.False(item2.Equals(item3));
-            Assert.False(item.Equals(new object()));
-            Assert.False(item.Equals(null!));
+            Assert.False(item1.Equals(new object()));
+            Assert.False(item1.Equals(null!));
         }
 
         [Fact]
         public void HashCodeEqualsTest()
         {
-            var item = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
             var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
-            Assert.Equal(item.GetHashCode(), item2.GetHashCode());
+            Assert.Equal(item1.GetHashCode(), item2.GetHashCode());
         }
 
         [Fact]
         public void HashCodeNotEqualsTest()
         {
-            var item = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
-            var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString());
-            Assert.NotEqual(item.GetHashCode(), item2.GetHashCode());
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
+            var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue2.ToString());
+            var item3 = new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString());
+            Assert.NotEqual(item1.GetHashCode(), item2.GetHashCode());
+            Assert.NotEqual(item2.GetHashCode(), item3.GetHashCode());
+            Assert.NotEqual(item1.GetHashCode(), item3.GetHashCode());
         }
 
         [Fact]
         public void OperatorEqualsTest()
         {
-            var item = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
             var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
-            Assert.True(item == item2);
-#pragma warning disable CS1718 // Comparison made to same variable
-            Assert.True(item == (ApiEnum)item);
-#pragma warning restore CS1718 // Comparison made to same variable
+            Assert.True(item1 == item2);
         }
 
         [Fact]
         public void OperatorNotEqualsTest()
         {
-            var item = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
             var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue2.ToString());
             var item3 = new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString());
-            Assert.True(item != item2);
-            Assert.True(item != item3);
+            Assert.True(item1 != item2);
+            Assert.True(item1 != item3);
             Assert.True(item2 != item3);
 #pragma warning disable CS0253 // Possible unintended reference comparison; right hand side needs cast
-            Assert.True(item != new object());
+            Assert.True(item1 != new object());
 #pragma warning restore CS0253 // Possible unintended reference comparison; right hand side needs cast
-            Assert.True(item != null!);
-
-            Assert.True((ApiEnum)item != item2);
+            Assert.True(item1 != null!);
         }
 
         #region ArgumentNullException tests

--- a/Gw2Sharp.Tests/WebApi/V2/Models/ApiFlagsTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Models/ApiFlagsTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Gw2Sharp.Tests.Helpers;
+using Gw2Sharp.WebApi.V2.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Gw2Sharp.Tests.WebApi.V2.Models
+{
+    public class ApiFlagsTests
+    {
+        [DefaultValue(EnumValue3)]
+        public enum TestEnum
+        {
+            EnumValue1 = 0,
+            EnumValue2,
+            EnumValue3
+        }
+
+        private class JsonObject
+        {
+            public ApiFlags<TestEnum> Flags { get; set; } = default!;
+        }
+
+        [Fact]
+        public void ConstructorTest()
+        {
+            var flags1 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2) });
+            var flags2 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2), new ApiEnum<TestEnum>(TestEnum.EnumValue3) });
+
+            Assert.Equal(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2) }, flags1.List);
+            Assert.Equal(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2), new ApiEnum<TestEnum>(TestEnum.EnumValue3) }, flags2.List);
+        }
+
+#nullable disable
+        public static IEnumerable<object[]> DeserializeTestData => new[]
+        {
+            new object[] { "{\"Flags\":[\"EnumValue2\"]}", new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2) } },
+            new object[] { "{\"Flags\":[\"EnumValue2\",\"EnumValue3\"]}", new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2), new ApiEnum<TestEnum>(TestEnum.EnumValue3) } },
+            new object[] { "{\"Flags\":[\"\"]}", new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue3, string.Empty) } },
+            new object[] { "{\"Flags\":[undefined]}", new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue3, null) } },
+            new object[] { "{\"Flags\":[]}", new ApiEnum<TestEnum>[0] },
+            new object[] { "{\"Flags\":undefined}", null },
+            new object[] { "{}", null },
+        };
+#nullable enable
+
+        [Theory]
+        [MemberData(nameof(DeserializeTestData))]
+        public void DeserializeTest(string json, ApiEnum<TestEnum>[] expected)
+        {
+            var obj = JsonConvert.DeserializeObject<JsonObject>(json);
+
+            if (expected == null)
+                Assert.Null(obj.Flags);
+            else
+                Assert.Equal(expected, obj.Flags.List);
+        }
+
+        [Fact]
+        public void HasUnknownTest()
+        {
+            var flags = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, "SomeRandomValue") });
+            Assert.True(flags.HasUnknowns);
+            Assert.Equal(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, "SomeRandomValue") }, flags.UnknownList);
+
+            flags = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            Assert.False(flags.HasUnknowns);
+            Assert.Empty(flags.UnknownList);
+
+            flags = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, "enumValue1") });
+            Assert.False(flags.HasUnknowns);
+            Assert.Empty(flags.UnknownList);
+
+            flags = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, "enum_value_1") });
+            Assert.False(flags.HasUnknowns);
+            Assert.Empty(flags.UnknownList);
+        }
+
+        [Fact]
+        public void ImplicitConversionFromListTest()
+        {
+            var expectedArray = new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString()) };
+            var expected = new ApiFlags<TestEnum>(expectedArray);
+            ApiFlags<TestEnum> actual = expectedArray;
+            Assert.Equal(expected, actual);
+
+            actual = new List<ApiEnum<TestEnum>>(expectedArray);
+            Assert.Equal(expected, actual);
+
+            actual = new Collection<ApiEnum<TestEnum>>(expectedArray);
+            Assert.Equal(expected, actual);
+
+            actual = new HashSet<ApiEnum<TestEnum>>(expectedArray);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ImplicitConversionToListTest()
+        {
+            var expected = new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2) };
+            ApiEnum<TestEnum>[] actualArray = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString()) });
+            Assert.Equal(expected, actualArray);
+
+            List<ApiEnum<TestEnum>> actualList = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString()) });
+            Assert.Equal(expected, actualList);
+        }
+
+        [Fact]
+        public void EqualsTest()
+        {
+            var item1 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            var item2 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            Assert.True(item1.Equals(item2));
+        }
+
+        [Fact]
+        public void NotEqualsTest()
+        {
+            var item1 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            var item2 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue2.ToString()) });
+            var item3 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString()) });
+            Assert.False(item1.Equals(item2));
+            Assert.False(item1.Equals(item3));
+            Assert.False(item2.Equals(item3));
+            Assert.False(item1.Equals(new object()));
+            Assert.False(item1.Equals(null!));
+        }
+
+        [Fact]
+        public void HashCodeEqualsTest()
+        {
+            var item1 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            var item2 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            Assert.Equal(item1.GetHashCode(), item2.GetHashCode());
+        }
+
+        [Fact]
+        public void HashCodeNotEqualsTest()
+        {
+            var item1 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            var item2 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue2.ToString()) });
+            var item3 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString()) });
+            Assert.NotEqual(item1.GetHashCode(), item2.GetHashCode());
+            Assert.NotEqual(item2.GetHashCode(), item3.GetHashCode());
+            Assert.NotEqual(item1.GetHashCode(), item3.GetHashCode());
+        }
+
+        [Fact]
+        public void OperatorEqualsTest()
+        {
+            var item1 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            var item2 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            Assert.True(item1 == item2);
+        }
+
+        [Fact]
+        public void OperatorNotEqualsTest()
+        {
+            var item1 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString()) });
+            var item2 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue2.ToString()) });
+            var item3 = new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue2, TestEnum.EnumValue2.ToString()) });
+            Assert.True(item1 != item2);
+            Assert.True(item1 != item3);
+            Assert.True(item2 != item3);
+#pragma warning disable CS0253 // Possible unintended reference comparison; right hand side needs cast
+            Assert.True(item1 != new object());
+#pragma warning restore CS0253 // Possible unintended reference comparison; right hand side needs cast
+            Assert.True(item1 != null!);
+        }
+
+        #region ArgumentNullException tests
+
+        [Fact]
+        public void ArgumentNullConstructorTest()
+        {
+            AssertArguments.ThrowsWhenNull(
+                () => new ApiFlags<TestEnum>(new[] { new ApiEnum<TestEnum>(TestEnum.EnumValue1) }),
+                new[] { true });
+        }
+
+        #endregion
+    }
+}

--- a/Gw2Sharp/Extensions/EnumExtensions.cs
+++ b/Gw2Sharp/Extensions/EnumExtensions.cs
@@ -15,14 +15,14 @@ namespace Gw2Sharp.Extensions
         /// </summary>
         /// <param name="value">The enum string to convert.</param>
         /// <param name="enumType">The enum type.</param>
-        /// <returns>The enum value, or <c>null</c> if parsing failed.</returns>
+        /// <returns>The enum value, or <c>default</c> if parsing failed.</returns>
         /// <exception cref="ArgumentException">
         /// <paramref name="enumType"/>is not an <see cref="Enum"/>.
         /// <paramref name="value"/> is a name, but not one of the named constants defined for the enumeration.
         /// </exception>
         /// <exception cref="ArgumentNullException"><paramref name="enumType"/> is <c>null</c>.</exception>
         /// <exception cref="OverflowException"><paramref name="value"/> is outside the range of the underlying type of <paramref name="enumType"/>.</exception>
-        public static Enum? ParseEnum(this string? value, Type enumType)
+        public static Enum ParseEnum(this string? value, Type enumType)
         {
             if (enumType == null)
                 throw new ArgumentNullException(nameof(enumType));
@@ -54,7 +54,20 @@ namespace Gw2Sharp.Extensions
                 if (enumType.GetTypeInfo().GetCustomAttribute(typeof(DefaultValueAttribute)) is DefaultValueAttribute attribute)
                     return (Enum)attribute.Value;
             }
-            return null;
+            return (Enum)Enum.ToObject(enumType, 0);
         }
+
+        /// <summary>
+        /// Parses a string into an enum.
+        /// </summary>
+        /// <typeparam name="T">The enum type.</typeparam>
+        /// <param name="value">The enum string to convert.</param>
+        /// <returns>The enum value, or <c>null</c> if parsing failed.</returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="value"/> is a name, but not one of the named constants defined for the enumeration.
+        /// </exception>
+        /// <exception cref="OverflowException"><paramref name="value"/> is outside the range of the underlying type of <typeparamref name="T"/>.</exception>
+        public static T ParseEnum<T>(this string? value) where T : Enum =>
+            (T)ParseEnum(value, typeof(T));
     }
 }

--- a/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
@@ -8,77 +8,9 @@ namespace Gw2Sharp.WebApi.V2.Models
     /// <summary>
     /// Wraps an API enum to allow unsupported and/or future enum values.
     /// </summary>
-    public abstract class ApiEnum : IEquatable<ApiEnum>
-    {
-        /// <summary>
-        /// Creates a new API enum.
-        /// </summary>
-        /// <param name="value">The enum value.</param>
-        /// <param name="rawValue">The raw value.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> or <paramref name="rawValue"/> is <c>null</c>.</exception>
-        protected ApiEnum(Enum value, string rawValue)
-        {
-            this.Value = value ?? throw new ArgumentNullException(nameof(value));
-            this.RawValue = rawValue ?? throw new ArgumentNullException(nameof(rawValue));
-        }
-
-        /// <summary>
-        /// Whether the enum value is unknown to the library.
-        /// If true, <see cref="RawValue" /> will contain the actual value whereas <see cref="Value" /> will have the default
-        /// value.
-        /// </summary>
-        public bool IsUnknown => !string.Equals(this.Value.ToString(), this.RawValue.Replace("_", ""), StringComparison.OrdinalIgnoreCase);
-
-        /// <summary>
-        /// The actual enum value as interpreted by the library.
-        /// </summary>
-        public Enum Value { get; }
-
-        /// <summary>
-        /// The raw enum value.
-        /// </summary>
-        public string RawValue { get; }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) =>
-            obj != null && obj.GetType() == typeof(ApiEnum) && this.Equals((ApiEnum)obj);
-
-        /// <inheritdoc />
-        public virtual bool Equals(ApiEnum other)
-        {
-            return !(other is null) &&
-                EqualityComparer<Enum>.Default.Equals(this.Value, other.Value) &&
-                this.RawValue == other.RawValue;
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            int hashCode = -1730349647;
-            hashCode = (hashCode * -1521134295) + EqualityComparer<Enum>.Default.GetHashCode(this.Value);
-            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.RawValue);
-            return hashCode;
-        }
-
-        /// <inheritdoc />
-        public override string ToString() =>
-            this.RawValue;
-
-        /// <inheritdoc />
-        public static bool operator ==(ApiEnum enum1, ApiEnum enum2) =>
-            EqualityComparer<ApiEnum>.Default.Equals(enum1, enum2);
-
-        /// <inheritdoc />
-        public static bool operator !=(ApiEnum enum1, ApiEnum enum2) =>
-            !(enum1 == enum2);
-    }
-
-    /// <summary>
-    /// Wraps an API enum to allow unsupported and/or future enum values.
-    /// </summary>
     /// <typeparam name="T">The enum type.</typeparam>
     [JsonConverter(typeof(ApiEnumConverter))]
-    public class ApiEnum<T> : ApiEnum, IEquatable<ApiEnum<T>> where T : Enum
+    public class ApiEnum<T> : IEquatable<ApiEnum<T>> where T : Enum
     {
         /// <summary>
         /// Creates a new API enum.
@@ -90,7 +22,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// </summary>
         /// <param name="value">The enum value.</param>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
-        public ApiEnum(T value) : this(value, null) { }
+        public ApiEnum(T value) : this(value, Enum.GetName(typeof(T), value)) { }
 
         /// <summary>
         /// Creates a new API enum.
@@ -98,51 +30,76 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <param name="value">The enum value.</param>
         /// <param name="rawValue">The raw value.</param>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
-        public ApiEnum(T value, string? rawValue) : base(value, rawValue ?? Enum.GetName(typeof(T), value)) { }
+        public ApiEnum(T value, string? rawValue)
+        {
+            this.Value = value ?? throw new ArgumentNullException(nameof(value));
+            this.RawValue = rawValue;
+        }
+
+
+        /// <summary>
+        /// Whether the enum value is unknown to the library.
+        /// If true, <see cref="RawValue" /> will contain the actual value whereas <see cref="Value" /> will have the default value.
+        /// </summary>
+        public bool IsUnknown => !string.Equals(this.Value.ToString(), this.RawValue?.Replace("_", ""), StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// The actual enum value as interpreted by the library.
         /// </summary>
-        public new T Value => (T)base.Value;
+        public T Value { get; }
+
+        /// <summary>
+        /// The raw enum value.
+        /// If the original value was <c>undefined</c> or <c>null</c>, this value is <c>null</c>.
+        /// </summary>
+        public string? RawValue { get; }
+
 
         /// <summary>
         /// Converts an enum to an API enum.
         /// </summary>
         /// <param name="e">The enum.</param>
-        public static implicit operator ApiEnum<T>(T e) => new ApiEnum<T>(e, e.ToString());
+        public static implicit operator ApiEnum<T>(T e) =>
+            new ApiEnum<T>(e, e.ToString());
 
         /// <summary>
         /// Converts an API enum to its normal enum.
         /// </summary>
         /// <param name="e">The API enum.</param>
-        public static implicit operator T(ApiEnum<T> e) => e.Value;
+        public static implicit operator T(ApiEnum<T> e) =>
+            e.Value;
 
         /// <summary>
         /// Converts an API enum to its raw string form.
         /// </summary>
-        /// <param name="e"></param>
-        public static implicit operator string(ApiEnum<T> e) => e.RawValue;
+        /// <param name="e">The API enum.</param>
+        public static implicit operator string?(ApiEnum<T> e) =>
+            e.RawValue;
 
         /// <inheritdoc />
         public override bool Equals(object? obj) =>
-            obj != null && obj.GetType() == typeof(ApiEnum<T>) && this.Equals((ApiEnum<T>)obj);
+            !(obj is null) && obj.GetType() == typeof(ApiEnum<T>) && this.Equals((ApiEnum<T>)obj);
 
         /// <inheritdoc />
         public virtual bool Equals(ApiEnum<T> other)
         {
             return !(other is null) &&
-                base.Equals(other) &&
-                EqualityComparer<T>.Default.Equals(this.Value, other.Value);
+                EqualityComparer<T>.Default.Equals(this.Value, other.Value) &&
+                this.RawValue == other.RawValue;
         }
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
             int hashCode = -159790080;
-            hashCode = (hashCode * -1521134295) + base.GetHashCode();
-            hashCode = (hashCode * -1521134295) + EqualityComparer<T>.Default.GetHashCode(this.Value);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<Enum>.Default.GetHashCode(this.Value);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.RawValue);
             return hashCode;
         }
+
+        /// <inheritdoc />
+        public override string? ToString() =>
+            this.RawValue;
 
         /// <inheritdoc />
         public static bool operator ==(ApiEnum<T> enum1, ApiEnum<T> enum2) =>

--- a/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
@@ -100,7 +100,8 @@ namespace Gw2Sharp.WebApi.V2.Models
         {
             int hashCode = -159790080;
             hashCode = (hashCode * -1521134295) + EqualityComparer<Enum>.Default.GetHashCode(this.Value);
-            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.RawValue);
+            if (this.RawValue != null)
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.RawValue);
             return hashCode;
         }
 

--- a/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Gw2Sharp.Extensions;
 using Gw2Sharp.Json.Converters;
 using Newtonsoft.Json;
 
@@ -29,10 +30,9 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// </summary>
         /// <param name="value">The enum value.</param>
         /// <param name="rawValue">The raw value.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
         public ApiEnum(T value, string? rawValue)
         {
-            this.Value = value ?? throw new ArgumentNullException(nameof(value));
+            this.Value = value;
             this.RawValue = rawValue;
         }
 
@@ -61,6 +61,13 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <param name="e">The enum.</param>
         public static implicit operator ApiEnum<T>(T e) =>
             new ApiEnum<T>(e, e.ToString());
+
+        /// <summary>
+        /// Converts a string to an API enum.
+        /// </summary>
+        /// <param name="e">The enum.</param>
+        public static implicit operator ApiEnum<T>(string e) =>
+            new ApiEnum<T>(e.ParseEnum<T>(), e);
 
         /// <summary>
         /// Converts an API enum to its normal enum.

--- a/Gw2Sharp/WebApi/V2/Models/ApiFlags.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ApiFlags.cs
@@ -11,23 +11,36 @@ namespace Gw2Sharp.WebApi.V2.Models
     /// <summary>
     /// Wraps a list an API enums into flags to allow unsupported and/or future enum values.
     /// </summary>
-    public abstract class ApiFlags : IEquatable<ApiFlags>, IEnumerable<ApiEnum>
+    /// <typeparam name="T">The enum type.</typeparam>
+    [JsonConverter(typeof(ApiFlagsConverter))]
+    public class ApiFlags<T> : IEquatable<ApiFlags<T>>, IEnumerable<ApiEnum<T>> where T : Enum
     {
         /// <summary>
         /// Creates new API flags.
         /// </summary>
-        protected ApiFlags() { }
+        public ApiFlags() { }
 
         /// <summary>
         /// Creates new API flags.
         /// </summary>
         /// <param name="list">The list of enum values.</param>
         /// <exception cref="ArgumentNullException"><paramref name="list"/> is <c>null</c>.</exception>
-        protected ApiFlags(IReadOnlyList<ApiEnum> list)
+        public ApiFlags(IEnumerable<ApiEnum<T>> list)
         {
-            this.List = list ?? throw new ArgumentNullException(nameof(list));
-            this.UnknownList = list.Where(e => e.IsUnknown).ToList().AsReadOnly();
+            this.List = list?.ToList()?.AsReadOnly() ?? throw new ArgumentNullException(nameof(list));
+            this.UnknownList = this.List.Where(e => e.IsUnknown).ToList().AsReadOnly();
         }
+
+        /// <summary>
+        /// Creates new API flags.
+        /// Used internally by <see cref="ApiFlagsConverter"/>.
+        /// </summary>
+        /// <param name="list">The list of enum values.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <c>null</c>.</exception>
+        internal ApiFlags(IEnumerable<object> list) :
+            this(list?.Cast<ApiEnum<T>>() ?? throw new ArgumentNullException(nameof(list)))
+        { }
+
 
         /// <summary>
         /// Whether the flags has at least one unknown value to the library.
@@ -38,112 +51,59 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The actual flags as interpreted by the library.
         /// </summary>
-        public IReadOnlyList<ApiEnum> List { get; protected set; } = new List<ApiEnum>();
+        public IReadOnlyList<ApiEnum<T>> List { get; } = new List<ApiEnum<T>>();
 
         /// <summary>
         /// Gets the list of unknown enum values.
         /// </summary>
-        public IReadOnlyList<ApiEnum> UnknownList { get; protected set; } = new List<ApiEnum>();
+        public IReadOnlyList<ApiEnum<T>> UnknownList { get; } = new List<ApiEnum<T>>();
 
-        /// <inheritdoc />
-        public override bool Equals(object? obj) =>
-            obj != null && obj.GetType() == typeof(ApiFlags) && this.Equals((ApiFlags)obj);
-
-        /// <inheritdoc />
-        public virtual bool Equals(ApiFlags other) =>
-            !(other is null) && this.List.SequenceEqual(other.List);
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return -2004394551 +
-                EqualityComparer<IReadOnlyList<ApiEnum>>.Default.GetHashCode(this.List);
-        }
-
-        /// <inheritdoc />
-        public IEnumerator<ApiEnum> GetEnumerator() =>
-            this.List.GetEnumerator();
-
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator() =>
-            this.GetEnumerator();
-
-        /// <inheritdoc />
-        public static bool operator ==(ApiFlags flags1, ApiFlags flags2) =>
-            EqualityComparer<ApiFlags>.Default.Equals(flags1, flags2);
-
-        /// <inheritdoc />
-        public static bool operator !=(ApiFlags flags1, ApiFlags flags2) =>
-            !(flags1 == flags2);
-    }
-
-    /// <summary>
-    /// Wraps a list an API enums into flags to allow unsupported and/or future enum values.
-    /// </summary>
-    /// <typeparam name="T">The enum type.</typeparam>
-    [JsonConverter(typeof(ApiFlagsConverter))]
-    public class ApiFlags<T> : ApiFlags, IEquatable<ApiFlags<T>>, IEnumerable<ApiEnum<T>> where T : Enum
-    {
-        /// <summary>
-        /// Creates new API flags.
-        /// </summary>
-        public ApiFlags() : base() { }
 
         /// <summary>
-        /// Creates new API flags.
+        /// Converts an array of enums to API flags.
         /// </summary>
-        /// <param name="list">The list of enum values.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <c>null</c>.</exception>
-        public ApiFlags(IReadOnlyList<ApiEnum> list) :
-            this(list.Select(e => new ApiEnum<T>((T)e.Value, e.RawValue)).ToList())
-        { }
-
-        /// <summary>
-        /// Creates new API flags.
-        /// </summary>
-        /// <param name="list">The list of enum values.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <c>null</c>.</exception>
-        public ApiFlags(IReadOnlyList<ApiEnum<T>> list) :
-            base(list)
-        { }
-
-        /// <summary>
-        /// The actual flags as interpreted by the library.
-        /// </summary>
-        public new IReadOnlyList<ApiEnum<T>> List => (IReadOnlyList<ApiEnum<T>>)base.List;
-
-        /// <summary>
-        /// Gets the list of unknown enum values.
-        /// </summary>
-        public new IReadOnlyList<ApiEnum<T>> UnknownList => (IReadOnlyList<ApiEnum<T>>)base.UnknownList;
+        /// <param name="l">The list of enums.</param>
+        public static implicit operator ApiFlags<T>(ApiEnum<T>[] l) =>
+            new ApiFlags<T>(l);
 
         /// <summary>
         /// Converts a list of enums to API flags.
         /// </summary>
         /// <param name="l">The list of enums.</param>
-        public static implicit operator ApiFlags<T>(List<ApiEnum<T>> l) => new ApiFlags<T>(l);
+        public static implicit operator ApiFlags<T>(List<ApiEnum<T>> l) =>
+            new ApiFlags<T>(l);
 
         /// <summary>
         /// Converts a collection of enums to API flags.
         /// </summary>
         /// <param name="l">The collection of enums.</param>
-        public static implicit operator ApiFlags<T>(Collection<ApiEnum<T>> l) => new ApiFlags<T>(l);
+        public static implicit operator ApiFlags<T>(Collection<ApiEnum<T>> l) =>
+            new ApiFlags<T>(l);
 
         /// <summary>
         /// Converts a set of enums to API flags.
         /// </summary>
         /// <param name="l">The set of enums.</param>
-        public static implicit operator ApiFlags<T>(HashSet<ApiEnum<T>> l) => new ApiFlags<T>(l.ToList());
+        public static implicit operator ApiFlags<T>(HashSet<ApiEnum<T>> l) =>
+            new ApiFlags<T>(l);
+
+        /// <summary>
+        /// Converts API flags to an array of enums.
+        /// </summary>
+        /// <param name="e">The API enum.</param>
+        public static implicit operator ApiEnum<T>[](ApiFlags<T> e) =>
+            e.List.ToArray();
 
         /// <summary>
         /// Converts API flags to a list of enums.
         /// </summary>
         /// <param name="e">The API enum.</param>
-        public static implicit operator List<ApiEnum<T>>(ApiFlags<T> e) => e.List.ToList();
+        public static implicit operator List<ApiEnum<T>>(ApiFlags<T> e) =>
+            e.List.ToList();
 
         /// <inheritdoc />
         public override bool Equals(object? obj) =>
-            obj != null && obj.GetType() == typeof(ApiFlags<T>) && this.Equals((ApiFlags<T>)obj);
+            !(obj is null) && obj.GetType() == typeof(ApiFlags<T>) && this.Equals((ApiFlags<T>)obj);
 
         /// <inheritdoc />
         public virtual bool Equals(ApiFlags<T> other) =>
@@ -153,14 +113,18 @@ namespace Gw2Sharp.WebApi.V2.Models
         public override int GetHashCode()
         {
             int hashCode = 1050334356;
-            hashCode = (hashCode * -1521134295) + base.GetHashCode();
-            hashCode = (hashCode * -1521134295) + EqualityComparer<IReadOnlyList<ApiEnum<T>>>.Default.GetHashCode(this.List);
+            foreach (var item in this.List)
+                hashCode = (hashCode * -1521134295) + EqualityComparer<ApiEnum<T>>.Default.GetHashCode(item);
             return hashCode;
         }
 
         /// <inheritdoc />
-        public new IEnumerator<ApiEnum<T>> GetEnumerator() =>
+        public IEnumerator<ApiEnum<T>> GetEnumerator() =>
             this.List.GetEnumerator();
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() =>
+            this.GetEnumerator();
 
         /// <inheritdoc />
         public static bool operator ==(ApiFlags<T> flags1, ApiFlags<T> flags2) =>

--- a/Gw2Sharp/WebApi/V2/Models/Guild/Guild.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Guild/Guild.cs
@@ -84,7 +84,8 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The guild emblem.
         /// No authentication required.
+        /// If the guild does not have an emblem, this value is <c>null</c>.
         /// </summary>
-        public GuildEmblem Emblem { get; set; } = new GuildEmblem();
+        public GuildEmblem? Emblem { get; set; }
     }
 }


### PR DESCRIPTION
The ApiEnum and ApiFlags classes are used to wrap possible unknown API enum values. In order to accomplish that, I created two variants of each class: the non-generic variant, and the generic variant. In practice, the user only uses the generic variant. The non-generic variant was there to support the custom JSON deserializer code. However, it causes issues like #10 when the default constructor was used. ApiFlags creates a list of ApiEnum objects, and because of the non-generic constructor, this was initialized as a list of ApiEnum objects, instead of a list of ApiEnum\<T\> objects. That causes an InvalidCastException when the list is accessed.

This change removes the non-generic variants of both classes, and changes the JSON deserializer to work with it. I also included tests for ApiFlags because frankly enough, I was too lazy to add them previously, but they are very much needed. I added a couple of more cases to handle undefined and null values from the API should they occur.

This also makes the guild emblem property nullable, as part of #10.

Resolves #10.