### PR TITLE
Update to .NET Core 3.0 release version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,10 +3,6 @@ version: '{build}'
 
 configuration: Debug
 
-environment:
-  SONAR_TOKEN:
-    secure: QDHrFOIyHrdnTjASRiMPjakQGHJzBeHDMVHBoqZ42GRwl2XUCWLdWTFIcMjDprMd
-
 skip_branch_with_pr: true
 
 branches:
@@ -15,8 +11,6 @@ branches:
 
 before_build:
   - dotnet restore
-  # - dotnet tool install --global dotnet-sonarscanner
-  # - choco install -y opencover.portable
   - ps: >-
       $version = Get-Content Gw2Sharp/Gw2Sharp.csproj | Select-String -Pattern '<Version>([^<]*)</Version>' -AllMatches | % { $_.Matches.Groups[1].Value }
 
@@ -25,27 +19,14 @@ before_build:
       Out-File Gw2Sharp/Gw2Sharp.csproj
 
       Update-AppveyorBuild -Version "$version-$env:APPVEYOR_BUILD_VERSION"
-  # - ps: >-
-  #     if (!(Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER)) {
-  #       if ($env:APPVEYOR_REPO_TAG -eq "true") {
-  #         dotnet sonarscanner begin /k:"Archomeda_Gw2Sharp" /o:"archomeda-github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.login="$env:SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="coverage.xml" /d:sonar.branch.name="$env:APPVEYOR_REPO_BRANCH" /v:"$env:APPVEYOR_REPO_TAG_NAME"
-  #       } else {
-  #         dotnet sonarscanner begin /k:"Archomeda_Gw2Sharp" /o:"archomeda-github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.login="$env:SONAR_TOKEN" /d:sonar.cs.opencover.reportsPaths="coverage.xml" /d:sonar.branch.name="$env:APPVEYOR_REPO_BRANCH"
-  #       }
-  #     }
 
 build:
   project: Gw2Sharp.sln
 
 test_script:
-  # - OpenCover.Console.exe -register:user -target:"C:\Program Files\dotnet\dotnet.exe" -returntargetcode -targetargs:"test Gw2Sharp.Tests/Gw2Sharp.Tests.csproj --configuration %CONFIGURATION% --no-build" -output:"coverage.xml" -oldStyle
   - dotnet test --configuration %CONFIGURATION% --no-build
 
 after_test:
-  # - ps: >-
-  #     if (!(Test-Path env:APPVEYOR_PULL_REQUEST_NUMBER)) {
-  #       dotnet sonarscanner end /d:sonar.login="$env:SONAR_TOKEN"
-  #     }
   - dotnet pack Gw2Sharp -c %CONFIGURATION% --no-build -o pack
   - ps: Remove-Item pack/*.symbols.nupkg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - 3.0.100-preview7-012821
-          #- 3.0.100-preview8-013656 # See #13
+          - 3.0.100-preview9-014004
         os:
           - ubuntu-latest
           - windows-latest
@@ -36,8 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - 3.0.100-preview7-012821
-          #- 3.0.100-preview8-013656 # See #13
+          - 3.0.100-preview9-014004
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1
@@ -74,8 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - 3.0.100-preview7-012821
-          #- 3.0.100-preview8-013656 # See #13
+          - 3.0.100-preview9-014004
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1.0.2 # Explicitly use v1.0.2 because of actions/setup-dotnet#29

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - 3.0.100-preview9-014004
+          - "3.0"
         os:
           - ubuntu-latest
           - windows-latest
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - 3.0.100-preview9-014004
+          - "3.0"
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - 3.0.100-preview9-014004
+          - "3.0"
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1.0.2 # Explicitly use v1.0.2 because of actions/setup-dotnet#29

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0"
+          - "3.0.100"
         os:
           - ubuntu-latest
           - windows-latest
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0"
+          - "3.0.100"
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0"
+          - "3.0.100"
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1.0.2 # Explicitly use v1.0.2 because of actions/setup-dotnet#29

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,8 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - 3.0.100-preview7-012821
-          #- 3.0.100-preview8-013656 # See #13
+          - "3.0"
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0"
+          - "3.0.100"
         os:
           - ubuntu-latest
           - windows-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: mcr.microsoft.com/dotnet/core/sdk:3.0.100-preview7
+image: mcr.microsoft.com/dotnet/core/sdk:3.0.100-preview9
 
 variables:
   CONFIGURATION: Release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: mcr.microsoft.com/dotnet/core/sdk:3.0.100-preview9
+image: mcr.microsoft.com/dotnet/core/sdk:3.0
 
 variables:
   CONFIGURATION: Release


### PR DESCRIPTION
This updates CI related files from .NET Core 3.0 Preview 7 to the release version of .NET Core 3.0.
Preview 8 and 9 were skipped due to bugs as mentioned in #13. And it seems that the release version is stable again.

Resolves #13