### PR TITLE
Use .NET Core 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0.100"
+          - "3.1.100"
         os:
           - ubuntu-latest
           - windows-latest
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0.100"
+          - "3.1.100"
     steps:
       - uses: actions/checkout@v1
       - uses: actions/download-artifact@v1
@@ -93,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0.100"
+          - "3.1.100"
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-dotnet@v1.0.2 # Explicitly use v1.0.2 because of actions/setup-dotnet#29

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         dotnet:
-          - "3.0.100"
+          - "3.1.100"
         os:
           - ubuntu-latest
           - windows-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: mcr.microsoft.com/dotnet/core/sdk:3.0
+image: mcr.microsoft.com/dotnet/core/sdk:3.1
 
 variables:
   CONFIGURATION: Release


### PR DESCRIPTION
Use .NET Core 3.1 for building the projects, because .NET Core 3.0 will be deprecated in the upcoming months.