### PR TITLE
Add null check to GuidConverter.

### DIFF
--- a/Gw2Sharp.Tests/TestFiles/Characters/Characters.bulk.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/Characters.bulk.json
@@ -142,7 +142,7 @@
     ],
     "profession": "Revenant",
     "level": 80,
-    "guild": "F00FF00F-F00F-F00F-F00F-F00FF00FF00F",
+    "guild": null,
     "age": 7441000,
     "last_modified": "2019-05-22T22:51:00Z",
     "created": "2014-01-31T18:00:00Z",

--- a/Gw2Sharp/Json/Converters/GuidConverter.cs
+++ b/Gw2Sharp/Json/Converters/GuidConverter.cs
@@ -13,13 +13,9 @@ namespace Gw2Sharp.Json.Converters
         public override bool CanWrite => false;
 
         /// <inheritdoc />
-        public override Guid ReadJson(JsonReader reader, Type objectType, Guid existingValue, bool hasExistingValue, JsonSerializer serializer)
-        {
-            if (reader.TokenType == JsonToken.Null) return null;
+        public override Guid ReadJson(JsonReader reader, Type objectType, Guid existingValue, bool hasExistingValue, JsonSerializer serializer) =>
+            reader.TokenType == JsonToken.Null ? Guid.Empty : new Guid(serializer.Deserialize<string>(reader));
 
-            return new Guid(serializer.Deserialize<string>(reader));
-        }
-            
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, Guid value, JsonSerializer serializer) =>
             throw new NotImplementedException("TODO: This should generally not be used since we only deserialize stuff from the API, and not serialize to it. Might add support later.");

--- a/Gw2Sharp/Json/Converters/GuidConverter.cs
+++ b/Gw2Sharp/Json/Converters/GuidConverter.cs
@@ -13,9 +13,13 @@ namespace Gw2Sharp.Json.Converters
         public override bool CanWrite => false;
 
         /// <inheritdoc />
-        public override Guid ReadJson(JsonReader reader, Type objectType, Guid existingValue, bool hasExistingValue, JsonSerializer serializer) =>
-            new Guid(serializer.Deserialize<string>(reader));
+        public override Guid ReadJson(JsonReader reader, Type objectType, Guid existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null) return null;
 
+            return new Guid(serializer.Deserialize<string>(reader));
+        }
+            
         /// <inheritdoc />
         public override void WriteJson(JsonWriter writer, Guid value, JsonSerializer serializer) =>
             throw new NotImplementedException("TODO: This should generally not be used since we only deserialize stuff from the API, and not serialize to it. Might add support later.");

--- a/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
@@ -50,8 +50,9 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The character's guild.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Guild"/>.
+        /// If the character is not representing a guild, this value is <c>null</c>.
         /// </summary>
-        public Guid Guild { get; set; }
+        public Guid? Guild { get; set; }
 
         /// <summary>
         /// The character's total play time.


### PR DESCRIPTION
Checks if reader TokenType is null.  If it is, it returns `Guid.Empty`, otherwise it returns the Guid.

Fixes #27.