### PR TITLE
Fix Truncated ArchiveCacheMethod

### DIFF
--- a/Gw2Sharp.Tests/WebApi/Caching/ArchiveCacheMethodTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Caching/ArchiveCacheMethodTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Text;
 using System.Threading.Tasks;
 using Gw2Sharp.Tests.Helpers;
 using Gw2Sharp.WebApi.Caching;
@@ -21,7 +23,7 @@ namespace Gw2Sharp.Tests.WebApi.Caching
 
 
         [Fact]
-        public async Task StoresCacheIntoArchiveTest()
+        public async Task StoresRawCacheIntoArchiveTest()
         {
             string category = "testdata";
             string id = "bytearray.dat";
@@ -42,6 +44,32 @@ namespace Gw2Sharp.Tests.WebApi.Caching
             await entryStream.CopyToAsync(memoryStream);
             byte[] actual = memoryStream.ToArray();
             Assert.Equal(data, actual);
+        }
+
+        [Fact]
+        public async Task StoresArrayCacheIntoArchiveTest()
+        {
+            string category = "testdata";
+            string id = "stringarray.dat";
+            var expiryTime = DateTimeOffset.UtcNow.AddMinutes(1);
+
+            string[] data = new[] { "Hello", "World!" };
+            await this.cacheMethod.SetAsync(category, id, data, expiryTime);
+            var actualCache = await this.cacheMethod.TryGetAsync<IEnumerable<string>>(category, id);
+
+            Assert.Equal(data, actualCache?.Item);
+            this.cacheMethod.Dispose();
+
+            using var stream = File.OpenRead(ARCHIVE_FILENAME);
+            var archive = new ZipArchive(stream);
+            var entry = archive.GetEntry($"{category}/{id}");
+            using var entryStream = entry.Open();
+            using var memoryStream = new MemoryStream();
+            await entryStream.CopyToAsync(memoryStream);
+
+            string expected = $"[\"{data[0]}\",\"{data[1]}\"]";
+            string actual = Encoding.UTF8.GetString(memoryStream.ToArray());
+            Assert.Equal(expected, actual);
         }
 
         [Fact]

--- a/Gw2Sharp/WebApi/Caching/ArchiveCacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/ArchiveCacheMethod.cs
@@ -219,7 +219,7 @@ namespace Gw2Sharp.WebApi.Caching
                 this.archive.Dispose();
                 this.archiveStream.Close();
                 this.archiveStream.Dispose();
-                this.archiveStream = File.Open(fileName, FileMode.Truncate, FileAccess.ReadWrite, FileShare.None);
+                this.archiveStream = File.Open(fileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                 this.archive = new ZipArchive(this.archiveStream, ZipArchiveMode.Update);
             }
         }


### PR DESCRIPTION
Currently when flushed, the `ArchiveCacheMethod` writes the archive to disk by disposing of the `archive` and `archiveStream`.  Once done, it reopens the archive so that it can be used for more caching.  Currently when reopening, the FileMode is set to `Truncate` immediately clearing the archive file that was just created as a result of the flush.

This PR just changes it to `OpenOrCreate` as it is when the `ArchiveCacheMethod` is first instanced.

Intended to fix #29 