### PR TITLE
Deprecate ICacheMethod.FlushAsync in favor of ClearAsync

### DIFF
--- a/Gw2Sharp.Tests/WebApi/Caching/BaseCacheMethodTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Caching/BaseCacheMethodTests.cs
@@ -26,7 +26,7 @@ namespace Gw2Sharp.Tests.WebApi.Caching
             await this.cacheMethod.SetAsync(cacheItem);
             Assert.Equal(cacheItem, await this.cacheMethod.TryGetAsync<int>(cacheItem.Category, cacheItem.Id));
 
-            await this.cacheMethod.FlushAsync();
+            await this.cacheMethod.ClearAsync();
             Assert.Null(await this.cacheMethod.TryGetAsync<int>(cacheItem.Category, cacheItem.Id));
         }
 

--- a/Gw2Sharp.Tests/WebApi/Caching/NullCacheMethodTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Caching/NullCacheMethodTests.cs
@@ -24,7 +24,7 @@ namespace Gw2Sharp.Tests.WebApi.Caching
             await this.cacheMethod.SetAsync(cacheItem);
             Assert.Null(await this.cacheMethod.TryGetAsync<int>(cacheItem.Category, cacheItem.Id));
 
-            await this.cacheMethod.FlushAsync();
+            await this.cacheMethod.ClearAsync();
             Assert.Null(await this.cacheMethod.TryGetAsync<int>(cacheItem.Category, cacheItem.Id));
         }
 

--- a/Gw2Sharp/WebApi/Caching/ArchiveCacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/ArchiveCacheMethod.cs
@@ -211,7 +211,7 @@ namespace Gw2Sharp.WebApi.Caching
         }
 
         /// <inheritdoc />
-        public override async Task FlushAsync()
+        public override async Task ClearAsync()
         {
             lock (this.operationLock)
             {

--- a/Gw2Sharp/WebApi/Caching/BaseCacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/BaseCacheMethod.cs
@@ -152,7 +152,12 @@ namespace Gw2Sharp.WebApi.Caching
         }
 
         /// <inheritdoc />
-        public abstract Task FlushAsync();
+        [Obsolete("Use ClearAsync instead. Will be removed starting with version 0.9.0")]
+        public Task FlushAsync() =>
+            this.ClearAsync();
+
+        /// <inheritdoc />
+        public abstract Task ClearAsync();
 
         /// <summary>
         /// Disposes the object.

--- a/Gw2Sharp/WebApi/Caching/ICacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/ICacheMethod.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// <param name="category">The cache category.</param>
         /// <param name="id">The id.</param>
         /// <returns>The task for this operation with a returned cached item if it exists and is not expired; <c>null</c> otherwise.</returns>
-        Task<CacheItem<T>?> TryGetAsync<T>(string category, object id) ;
+        Task<CacheItem<T>?> TryGetAsync<T>(string category, object id);
 
         /// <summary>
         /// Sets a cached item.
@@ -24,7 +24,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// <typeparam name="T">The cache type.</typeparam>
         /// <param name="item">The item to cache.</param>
         /// <returns>The task for this operation.</returns>
-        Task SetAsync<T>(CacheItem<T> item) ;
+        Task SetAsync<T>(CacheItem<T> item);
 
         /// <summary>
         /// Sets a cached item.
@@ -35,7 +35,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// <param name="item">The item to cache.</param>
         /// <param name="expiryTime">The expiry time.</param>
         /// <returns>The task for this operation.</returns>
-        Task SetAsync<T>(string category, object id, T item, DateTimeOffset expiryTime) ;
+        Task SetAsync<T>(string category, object id, T item, DateTimeOffset expiryTime);
 
         /// <summary>
         /// Gets many cached items of a given type at once.
@@ -47,7 +47,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// The task for this operation with the cached items if they exist and have not expired.
         /// Only items that exist are included in the returned dictionary.
         /// </returns>
-        Task<IDictionary<object, CacheItem<T>>> GetManyAsync<T>(string category, IEnumerable<object> ids) ;
+        Task<IDictionary<object, CacheItem<T>>> GetManyAsync<T>(string category, IEnumerable<object> ids);
 
         /// <summary>
         /// Sets many cached items of a given type at once.
@@ -55,7 +55,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// <typeparam name="T">The cache type.</typeparam>
         /// <param name="items">The items.</param>
         /// <returns>The task for this operation.</returns>
-        Task SetManyAsync<T>(IEnumerable<CacheItem<T>> items) ;
+        Task SetManyAsync<T>(IEnumerable<CacheItem<T>> items);
 
         /// <summary>
         /// Gets a cached item if it exists. If it doesn't exist, it calls <paramref name="updateFunc"/> to provide an updated value,
@@ -67,7 +67,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// <param name="expiryTime">The expiry date.</param>
         /// <param name="updateFunc">The method that is called when no cache has been found.</param>
         /// <returns>The item.</returns>
-        Task<CacheItem<T>> GetOrUpdateAsync<T>(string category, object id, DateTimeOffset expiryTime, Func<Task<T>> updateFunc) ;
+        Task<CacheItem<T>> GetOrUpdateAsync<T>(string category, object id, DateTimeOffset expiryTime, Func<Task<T>> updateFunc);
 
         /// <summary>
         /// Gets a cached item if it exists. If it doesn't exist, it calls <paramref name="updateFunc"/> to provide an updated value and its expiry date,
@@ -78,7 +78,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// <param name="id">The cache id.</param>
         /// <param name="updateFunc">The method that is called when no cache has been found.</param>
         /// <returns>The item.</returns>
-        Task<CacheItem<T>> GetOrUpdateAsync<T>(string category, object id, Func<Task<(T, DateTimeOffset)>> updateFunc) ;
+        Task<CacheItem<T>> GetOrUpdateAsync<T>(string category, object id, Func<Task<(T, DateTimeOffset)>> updateFunc);
 
         /// <summary>
         /// Gets cached items if they exist. If one or more don't exist, <paramref name="updateFunc"/> will be called to provide updated values and their expiry date,
@@ -111,9 +111,16 @@ namespace Gw2Sharp.WebApi.Caching
             Func<IList<object>, Task<IDictionary<object, T>>> updateFunc);
 
         /// <summary>
-        /// Flushes the cache, a.k.a. empties the cache.
+        /// Clears the cache, a.k.a. empties the cache.
         /// </summary>
         /// <returns>The task for this operation.</returns>
+        [Obsolete("Use ClearAsync instead. Will be removed starting with version 0.9.0")]
         Task FlushAsync();
+
+        /// <summary>
+        /// Clears the cache, a.k.a. empties the cache.
+        /// </summary>
+        /// <returns>The task for this operation.</returns>
+        Task ClearAsync();
     }
 }

--- a/Gw2Sharp/WebApi/Caching/MemoryCacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/MemoryCacheMethod.cs
@@ -123,7 +123,7 @@ namespace Gw2Sharp.WebApi.Caching
         }
 
         /// <inheritdoc />
-        public override async Task FlushAsync() =>
+        public override async Task ClearAsync() =>
             this.cachedItems.Clear();
 
         private bool isDisposed = false; // To detect redundant calls

--- a/Gw2Sharp/WebApi/Caching/NullCacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/NullCacheMethod.cs
@@ -40,7 +40,7 @@ namespace Gw2Sharp.WebApi.Caching
         }
 
         /// <inheritdoc />
-        public override async Task FlushAsync()
+        public override async Task ClearAsync()
         {
             // Nothing to do
         }


### PR DESCRIPTION
Starting with v0.8.0 this method will be named differently to avoid confusion.
The old method is deprecated first, and in v0.9.0 and higher it will be removed.