### PR TITLE
Compare ApiEnum's raw values case insensitively

### DIFF
--- a/Gw2Sharp.Tests/WebApi/V2/Models/ApiEnumTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Models/ApiEnumTests.cs
@@ -113,6 +113,14 @@ namespace Gw2Sharp.Tests.WebApi.V2.Models
         }
 
         [Fact]
+        public void CaseInsensitiveEqualsTest()
+        {
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, "enumValue1");
+            var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, "Enumvalue1");
+            Assert.True(item1.Equals(item2));
+        }
+
+        [Fact]
         public void NotEqualsTest()
         {
             var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
@@ -130,6 +138,14 @@ namespace Gw2Sharp.Tests.WebApi.V2.Models
         {
             var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
             var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, TestEnum.EnumValue1.ToString());
+            Assert.Equal(item1.GetHashCode(), item2.GetHashCode());
+        }
+
+        [Fact]
+        public void CaseInsensitiveHashCodeEqualsTest()
+        {
+            var item1 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, "enumValue1");
+            var item2 = new ApiEnum<TestEnum>(TestEnum.EnumValue1, "Enumvalue1");
             Assert.Equal(item1.GetHashCode(), item2.GetHashCode());
         }
 

--- a/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
@@ -92,7 +92,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         {
             return !(other is null) &&
                 EqualityComparer<T>.Default.Equals(this.Value, other.Value) &&
-                this.RawValue == other.RawValue;
+                EqualityComparer<string>.Default.Equals(this.RawValue?.ToLowerInvariant(), other.RawValue?.ToLowerInvariant());
         }
 
         /// <inheritdoc />
@@ -101,7 +101,7 @@ namespace Gw2Sharp.WebApi.V2.Models
             int hashCode = -159790080;
             hashCode = (hashCode * -1521134295) + EqualityComparer<Enum>.Default.GetHashCode(this.Value);
             if (this.RawValue != null)
-                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.RawValue);
+                hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.RawValue.ToLowerInvariant());
             return hashCode;
         }
 


### PR DESCRIPTION
For example, the TokenPermissions enum is PascalCase in Gw2Sharp, while the API lists the permissions in camelCase (or just lowercase). When checking if an enum is present in these flags, it will fail if the casing is incorrect.

The solution is to compare them case insensitively, since we're deserializing the enums case insensitively anyway.