### PR TITLE
Combine shared enums usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Gw2Sharp History
 
+## 0.9.0
+### Services
+- Various web API endpoints have been extended to support enums as ids with automatic conversion to their API id type
+  - To support this, the interface `Gw2Sharp.WebApi.V2.Clients.IBulkAliasExpandableClient` has been added
+  - `Gw2Sharp.WebApi.V2.Clients.ILegendsClient` now implements `Gw2Sharp.WebApi.V2.Clients.IBulkAliasExpandableClient` and supports requesting `GetAsync` and `ManyAsync` with `Gw2Sharp.Models.LegendType` as id type
+  - `Gw2Sharp.WebApi.V2.Clients.IProfessionClient` now implements `Gw2Sharp.WebApi.V2.Clients.IBulkAliasExpandableClient` and supports requesting `GetAsync` and `ManyAsync` with `Gw2Sharp.Models.ProfessionType` as id type
+  - `Gw2Sharp.WebApi.V2.Clients.IRaceClient` now implements `Gw2Sharp.WebApi.V2.Clients.IBulkAliasExpandableClient` and supports requesting `GetAsync` and `ManyAsync` with `Gw2Sharp.Models.RaceType` as id type
+- **Breaking:** The `Race` property in the Mumble Client is now of type `RaceType` instead of `string`
+
+### Refactoring
+- **Breaking:** `Gw2Sharp.Models.Legend` has been renamed to `Gw2Sharp.Models.LegendType`
+- **Breaking:** `Gw2Sharp.Models.Profession` has been renamed to `Gw2Sharp.Models.ProfessionType`
+- `Gw2Sharp.Mumble.Models.Race` has been renamed to `Gw2Sharp.Models.RaceType` and is now public instead of internal
+
+---
+
 ## 0.8.2
 ### Fixes
 - Fix API enum comparison with different character casings ([#36](https://github.com/Archomeda/Gw2Sharp/pull/36))

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 0.8.3
+next-version: 0.9.0
 assembly-versioning-format: '{MajorMinorPatch}.0'
 assembly-file-versioning-format: '{MajorMinorPatch}-{BranchName}.{CommitsSinceVersionSource}+{ShortSha}'
 assembly-informational-format: '{MajorMinorPatch}-{BranchName}.{CommitsSinceVersionSource}+{ShortSha}'

--- a/Gw2Sharp.Tests/ChatLinks/BuildChatLinkTests.cs
+++ b/Gw2Sharp.Tests/ChatLinks/BuildChatLinkTests.cs
@@ -11,7 +11,7 @@ namespace Gw2Sharp.Tests.ChatLinks
         {
             new object[] { "[&DQIzNSQtEipwAHAA1xJxANwSqgDEEqwAwhKcAAAAAAAAAAAAAAAAAAAAAAA=]", new BuildChatLink
             {
-                Profession = Profession.Warrior,
+                Profession = ProfessionType.Warrior,
                 Specialization1Id = 51,
                 Specialization1Trait1Index = 1,
                 Specialization1Trait2Index = 1,
@@ -50,18 +50,18 @@ namespace Gw2Sharp.Tests.ChatLinks
         [Fact]
         public void EqualsTest()
         {
-            var chatLink = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink2 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink2 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
             Assert.True(chatLink.Equals((object)chatLink2));
         }
 
         [Fact]
         public void NotEqualsTest()
         {
-            var chatLink = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink2 = new BuildChatLink { Profession = Profession.Guardian, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink3 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 222, Specialization2Id = 100, Specialization3Id = 14 };
-            var chatLink4 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 147 };
+            var chatLink = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink2 = new BuildChatLink { Profession = ProfessionType.Guardian, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink3 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 222, Specialization2Id = 100, Specialization3Id = 14 };
+            var chatLink4 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 147 };
             Assert.False(chatLink.Equals(chatLink2));
             Assert.False(chatLink.Equals(chatLink3));
             Assert.False(chatLink.Equals(chatLink4));
@@ -77,18 +77,18 @@ namespace Gw2Sharp.Tests.ChatLinks
         [Fact]
         public void OperatorEqualsTest()
         {
-            var chatLink = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink2 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink2 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
             Assert.True(chatLink == chatLink2);
         }
 
         [Fact]
         public void OperatorNotEqualsTest()
         {
-            var chatLink = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink2 = new BuildChatLink { Profession = Profession.Guardian, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink3 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 222, Specialization2Id = 100, Specialization3Id = 14 };
-            var chatLink4 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 147 };
+            var chatLink = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink2 = new BuildChatLink { Profession = ProfessionType.Guardian, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink3 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 222, Specialization2Id = 100, Specialization3Id = 14 };
+            var chatLink4 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 147 };
             Assert.True(chatLink != chatLink2);
             Assert.True(chatLink != chatLink3);
             Assert.True(chatLink != chatLink4);
@@ -100,18 +100,18 @@ namespace Gw2Sharp.Tests.ChatLinks
         [Fact]
         public void HashCodeEqualsTest()
         {
-            var chatLink = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink2 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink2 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
             Assert.Equal(chatLink.GetHashCode(), chatLink2.GetHashCode());
         }
 
         [Fact]
         public void HashCodeNotEqualsTest()
         {
-            var chatLink = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink2 = new BuildChatLink { Profession = Profession.Guardian, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
-            var chatLink3 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 222, Specialization2Id = 100, Specialization3Id = 14 };
-            var chatLink4 = new BuildChatLink { Profession = Profession.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 147 };
+            var chatLink = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink2 = new BuildChatLink { Profession = ProfessionType.Guardian, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 14 };
+            var chatLink3 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 222, Specialization2Id = 100, Specialization3Id = 14 };
+            var chatLink4 = new BuildChatLink { Profession = ProfessionType.Warrior, Specialization1Id = 123, Specialization2Id = 234, Specialization3Id = 147 };
             Assert.NotEqual(chatLink.GetHashCode(), chatLink2.GetHashCode());
             Assert.NotEqual(chatLink.GetHashCode(), chatLink3.GetHashCode());
             Assert.NotEqual(chatLink.GetHashCode(), chatLink4.GetHashCode());

--- a/Gw2Sharp.Tests/Mumble/Gw2MumbleClientTests.cs
+++ b/Gw2Sharp.Tests/Mumble/Gw2MumbleClientTests.cs
@@ -45,8 +45,8 @@ namespace Gw2Sharp.Tests.Mumble
             Assert.Equal(-0.3139677, client.CameraFront.Y, 7);
             Assert.Equal(-0.4892152, client.CameraFront.Z, 7);
             Assert.Equal("Reiga Fiercecrusher", client.CharacterName);
-            Assert.Equal(Profession.Warrior, client.Profession);
-            Assert.Equal("Charr", client.Race);
+            Assert.Equal(ProfessionType.Warrior, client.Profession);
+            Assert.Equal(RaceType.Charr, client.Race);
             Assert.Equal(18, client.Specialization);
             Assert.Equal(0, client.TeamColorId);
             Assert.False(client.IsCommander);

--- a/Gw2Sharp/ChatLinks/BuildChatLink.cs
+++ b/Gw2Sharp/ChatLinks/BuildChatLink.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.ChatLinks
         /// <summary>
         /// The profession.
         /// </summary>
-        public Profession Profession
+        public ProfessionType Profession
         {
             get => this.data.Profession;
             set => this.data.Profession = value;

--- a/Gw2Sharp/ChatLinks/Structs/BuildChatLinkStruct.cs
+++ b/Gw2Sharp/ChatLinks/Structs/BuildChatLinkStruct.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.ChatLinks.Structs
         /// Matches <see cref="WebApi.V2.Models.Profession.Code"/> in <see cref="IGw2WebApiV2Client.Professions"/>.
         /// </summary>
         [FieldOffset(0)]
-        public Profession Profession;
+        public ProfessionType Profession;
 
         /// <summary>
         /// The first specialization id.

--- a/Gw2Sharp/Gw2Sharp.csproj
+++ b/Gw2Sharp/Gw2Sharp.csproj
@@ -10,7 +10,7 @@
     <GenerateNullableAttributes>true</GenerateNullableAttributes>
 
     <PackageId>Gw2Sharp</PackageId>
-    <Version>0.8.3</Version>
+    <Version>0.9.0</Version>
     <Authors>Archomeda</Authors>
     <Description>
 Gw2Sharp is a .NET wrapper library for the official Guild Wars 2 API.

--- a/Gw2Sharp/Models/LegendType.cs
+++ b/Gw2Sharp/Models/LegendType.cs
@@ -4,7 +4,7 @@ namespace Gw2Sharp.Models
     /// Represents a legend.
     /// Used by chat links.
     /// </summary>
-    public enum Legend : byte
+    public enum LegendType : byte
     {
         /// <summary>
         /// Glint.

--- a/Gw2Sharp/Models/ProfessionType.cs
+++ b/Gw2Sharp/Models/ProfessionType.cs
@@ -4,7 +4,7 @@ namespace Gw2Sharp.Models
     /// Represents a profession.
     /// Used by Mumble Link and chat links.
     /// </summary>
-    public enum Profession : byte
+    public enum ProfessionType : byte
     {
         /// <summary>
         /// Guardian.

--- a/Gw2Sharp/Models/RaceType.cs
+++ b/Gw2Sharp/Models/RaceType.cs
@@ -1,9 +1,10 @@
-namespace Gw2Sharp.Mumble.Models
+namespace Gw2Sharp.Models
 {
     /// <summary>
-    /// The race.
+    /// Represents a race.
+    /// Used by Mumble Link.
     /// </summary>
-    internal enum Race
+    public enum RaceType : byte
     {
         /// <summary>
         /// Asura.

--- a/Gw2Sharp/Mumble/Gw2MumbleClient.cs
+++ b/Gw2Sharp/Mumble/Gw2MumbleClient.cs
@@ -184,16 +184,16 @@ namespace Gw2Sharp.Mumble
             this.IsAvailable ? this.Identity.Name : string.Empty;
 
         /// <inheritdoc />
-        public Profession Profession =>
-            this.IsAvailable ? this.Identity.Profession : (Profession)0;
+        public ProfessionType Profession =>
+            this.IsAvailable ? this.Identity.Profession : 0;
 
         /// <inheritdoc />
         public int Specialization =>
             this.IsAvailable ? this.Identity.Spec : 0;
 
         /// <inheritdoc />
-        public string Race =>
-            this.IsAvailable ? this.Identity.Race.ToString() : string.Empty;
+        public RaceType Race =>
+            this.IsAvailable ? this.Identity.Race : 0;
 
         /// <inheritdoc />
         public int TeamColorId =>

--- a/Gw2Sharp/Mumble/IGw2MumbleClient.cs
+++ b/Gw2Sharp/Mumble/IGw2MumbleClient.cs
@@ -172,9 +172,9 @@ namespace Gw2Sharp.Mumble
 
         /// <summary>
         /// The character profession.
-        /// Can be resolved against <see cref="IGw2WebApiV2Client.Professions"/> if converted to string.
+        /// Can be resolved against <see cref="IGw2WebApiV2Client.Professions"/>.
         /// </summary>
-        Profession Profession { get; }
+        ProfessionType Profession { get; }
 
         /// <summary>
         /// The character's currently equipped third specialization.
@@ -187,7 +187,7 @@ namespace Gw2Sharp.Mumble
         /// The character race.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Races"/>.
         /// </summary>
-        string Race { get; }
+        RaceType Race { get; }
 
         /// <summary>
         /// The current team color.

--- a/Gw2Sharp/Mumble/Models/CharacterIdentity.cs
+++ b/Gw2Sharp/Mumble/Models/CharacterIdentity.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.Mumble.Models
         /// <summary>
         /// The character profession.
         /// </summary>
-        public Profession Profession { get; set; }
+        public ProfessionType Profession { get; set; }
 
         /// <summary>
         /// The character specialization.
@@ -26,7 +26,7 @@ namespace Gw2Sharp.Mumble.Models
         /// <summary>
         /// The character race.
         /// </summary>
-        public Race Race { get; set; }
+        public RaceType Race { get; set; }
 
         /// <summary>
         /// The team color id.

--- a/Gw2Sharp/WebApi/V2/Clients/IBulkAliasExpandableClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/IBulkAliasExpandableClient.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gw2Sharp.WebApi.V2.Clients
+{
+    /// <summary>
+    /// Implements an endpoint client that is bulk expandable with an aliased type.
+    /// </summary>
+    /// <typeparam name="TObject">The response object type.</typeparam>
+    /// <typeparam name="TId">The id value type.</typeparam>
+    public interface IBulkAliasExpandableClient<TObject, TId> : IEndpointClient
+        where TObject : IApiV2Object
+    {
+        /// <summary>
+        /// Requests a single entry by id.
+        /// </summary>
+        /// <param name="id">The entry id.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The entry.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="id"/> is <c>null</c>.</exception>
+        Task<TObject> GetAsync(TId id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Requests many entries by their id (a.k.a. bulk expansion).
+        /// </summary>
+        /// <param name="ids">The entry ids.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The entries.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="ids"/> is <c>null</c>.</exception>
+        Task<IReadOnlyList<TObject>> ManyAsync(IEnumerable<TId> ids, CancellationToken cancellationToken = default);
+    }
+}

--- a/Gw2Sharp/WebApi/V2/Clients/Legends/ILegendsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Legends/ILegendsClient.cs
@@ -1,3 +1,4 @@
+using Gw2Sharp.Models;
 using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.V2.Clients
@@ -8,6 +9,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     public interface ILegendsClient :
         IAllExpandableClient<Legend>,
         IBulkExpandableClient<Legend, string>,
+        IBulkAliasExpandableClient<Legend, LegendType>,
         IPaginatedClient<Legend>
     {
     }

--- a/Gw2Sharp/WebApi/V2/Clients/Legends/LegendsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Legends/LegendsClient.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gw2Sharp.Models;
 using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.V2.Clients
@@ -19,5 +24,13 @@ namespace Gw2Sharp.WebApi.V2.Clients
         protected internal LegendsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }
+
+        /// <inheritdoc />
+        public Task<Legend> GetAsync(LegendType id, CancellationToken cancellationToken = default) =>
+            this.GetAsync(id.ToString(), cancellationToken);
+
+        /// <inheritdoc />
+        public Task<IReadOnlyList<Legend>> ManyAsync(IEnumerable<LegendType> ids, CancellationToken cancellationToken = default) =>
+            this.ManyAsync(ids.Select(x => x.ToString()), cancellationToken);
     }
 }

--- a/Gw2Sharp/WebApi/V2/Clients/Professions/IProfessionsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Professions/IProfessionsClient.cs
@@ -1,3 +1,4 @@
+using Gw2Sharp.Models;
 using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.V2.Clients
@@ -8,6 +9,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     public interface IProfessionsClient :
         IAllExpandableClient<Profession>,
         IBulkExpandableClient<Profession, string>,
+        IBulkAliasExpandableClient<Profession, ProfessionType>,
         ILocalizedClient<Profession>,
         IPaginatedClient<Profession>
     {

--- a/Gw2Sharp/WebApi/V2/Clients/Professions/ProfessionsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Professions/ProfessionsClient.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gw2Sharp.Models;
 using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.V2.Clients
@@ -19,5 +24,13 @@ namespace Gw2Sharp.WebApi.V2.Clients
         protected internal ProfessionsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }
+
+        /// <inheritdoc />
+        public Task<Profession> GetAsync(ProfessionType id, CancellationToken cancellationToken = default) =>
+            this.GetAsync(id.ToString(), cancellationToken);
+
+        /// <inheritdoc />
+        public Task<IReadOnlyList<Profession>> ManyAsync(IEnumerable<ProfessionType> ids, CancellationToken cancellationToken = default) =>
+            this.ManyAsync(ids.Select(x => x.ToString()), cancellationToken);
     }
 }

--- a/Gw2Sharp/WebApi/V2/Clients/Races/IRacesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Races/IRacesClient.cs
@@ -1,3 +1,4 @@
+using Gw2Sharp.Models;
 using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.V2.Clients
@@ -8,6 +9,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     public interface IRacesClient :
         IAllExpandableClient<Race>,
         IBulkExpandableClient<Race, string>,
+        IBulkAliasExpandableClient<Race, RaceType>,
         ILocalizedClient<Race>,
         IPaginatedClient<Race>
     {

--- a/Gw2Sharp/WebApi/V2/Clients/Races/RacesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Races/RacesClient.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gw2Sharp.Models;
 using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.V2.Clients
@@ -18,5 +23,13 @@ namespace Gw2Sharp.WebApi.V2.Clients
         protected internal RacesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }
+
+        /// <inheritdoc />
+        public Task<Race> GetAsync(RaceType id, CancellationToken cancellationToken = default) =>
+            this.GetAsync(id.ToString(), cancellationToken);
+
+        /// <inheritdoc />
+        public Task<IReadOnlyList<Race>> ManyAsync(IEnumerable<RaceType> ids, CancellationToken cancellationToken = default) =>
+            this.ManyAsync(ids.Select(x => x.ToString()), cancellationToken);
     }
 }

--- a/MumbleLinkReader/Form1.cs
+++ b/MumbleLinkReader/Form1.cs
@@ -126,7 +126,7 @@ namespace MumbleLinkReader
                             this.textBoxCameraFront3.Text = m.CameraFront.Z.ToString();
 
                             this.textBoxCharacterName.Text = m.CharacterName;
-                            this.textBoxRace.Text = m.Race;
+                            this.textBoxRace.Text = m.Race.ToString();
                             this.textBoxSpecialization.Text = m.Specialization.ToString();
                             this.textBoxTeamColorId.Text = m.TeamColorId.ToString();
                             this.checkBoxCommander.Checked = m.IsCommander;


### PR DESCRIPTION
Closes #40.

After looking through the code, there was no reason why it was done this way. The original intention was to emulate the expected id type in the web API, which is a string (as was done with the race). However, the profession was using an enum type. This introduced inconsistency.

This PR resolves this inconsistency. For easiness, the Mumble Client returns enums now. And the respective endpoints that accept either a legend, profession or race as id, will also accept these enum counterparts.

This is a breaking change, and will be introduced in v0.9.0.