### PR TITLE
Skip unnecessarily comparing strings for Mumble identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `Gw2Sharp.WebApi.V2.Clients.IProfessionClient` now implements `Gw2Sharp.WebApi.V2.Clients.IBulkAliasExpandableClient` and supports requesting `GetAsync` and `ManyAsync` with `Gw2Sharp.Models.ProfessionType` as id type
   - `Gw2Sharp.WebApi.V2.Clients.IRaceClient` now implements `Gw2Sharp.WebApi.V2.Clients.IBulkAliasExpandableClient` and supports requesting `GetAsync` and `ManyAsync` with `Gw2Sharp.Models.RaceType` as id type
 - **Breaking:** The `Race` property in the Mumble Client is now of type `RaceType` instead of `string`
+- Repeatedly requesting Mumble identity fields (or just requesting multiple) should be a bit faster now
 
 ### Refactoring
 - **Breaking:** `Gw2Sharp.Models.Legend` has been renamed to `Gw2Sharp.Models.LegendType`

--- a/Gw2Sharp/Mumble/Gw2MumbleClient.cs
+++ b/Gw2Sharp/Mumble/Gw2MumbleClient.cs
@@ -40,6 +40,7 @@ namespace Gw2Sharp.Mumble
                 () => this.memoryMappedFile.Value.CreateViewAccessor(), true);
         }
 
+        private bool hasNewIdentity = false;
         private string currentIdentityJson = EMPTY_IDENTITY;
         private string? newIdentityJson;
         private CharacterIdentity? identityObject;
@@ -47,8 +48,9 @@ namespace Gw2Sharp.Mumble
         {
             get
             {
-                if (this.identityObject == null || (this.newIdentityJson != null && this.newIdentityJson != this.currentIdentityJson))
+                if (this.identityObject == null || (this.hasNewIdentity && this.newIdentityJson != null && this.newIdentityJson != this.currentIdentityJson))
                 {
+                    this.hasNewIdentity = false;
                     this.currentIdentityJson = this.newIdentityJson ?? EMPTY_IDENTITY;
                     this.newIdentityJson = null;
                     this.identityObject = JsonConvert.DeserializeObject<CharacterIdentity>(this.currentIdentityJson);
@@ -228,6 +230,7 @@ namespace Gw2Sharp.Mumble
             {
                 // There's actually a possible identity update
                 this.newIdentityJson = new string(linkedMem.identity);
+                this.hasNewIdentity = true;
             }
             else if (!this.IsAvailable)
             {


### PR DESCRIPTION
Closes #39.

Added a boolean that indicates whether the Mumble identity has already been compared to the previous one.
Without this boolean, requesting an identity field will always compare the JSON strings to see if the identity has been updated since last time. This causes an overhead when we can just set a boolean that will be reset when it's actually updated and we need to check the strings again.