### PR TITLE
Add 2v2Ranked in PvpRatingType

### DIFF
--- a/Gw2Sharp.Tests/TestFiles/Pvp/PvpGames.bulk.json
+++ b/Gw2Sharp.Tests/TestFiles/Pvp/PvpGames.bulk.json
@@ -45,5 +45,21 @@
       "red": 329,
       "blue": 502
     }
+  },
+  {
+    "id": "095D44FD-0C72-4176-A53D-D14E10EF413B",
+    "map_id": 1201,
+    "started": "2020-03-12T21:03:18.288Z",
+    "ended": "2020-03-12T21:04:26.288Z",
+    "result": "Victory",
+    "team": "Blue",
+    "profession": "Warrior",
+    "rating_type": "2v2Ranked",
+    "rating_change": 10,
+    "season": "91C6E5B8-6CA7-4C2B-9F8E-BCA8EDD0653A",
+    "scores": {
+      "red": 0,
+      "blue": 0
+    }
   }
 ]

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -398,7 +399,8 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
                     Assert.Equal(expected.GetString(), @enum.RawValue);
                     if (@enum.IsUnknown)
                     {
-                        var enumNames = Enum.GetNames(enumType).Select(x => x.Replace("_", ""));
+                        var enumNames = Enum.GetNames(enumType).Select(x => x.Replace("_", ""))
+                            .Select(x => enumType.GetField(x).GetCustomAttribute<EnumMemberAttribute>()?.Value ?? x);
                         Assert.True(enumNames.Contains((string)@enum.RawValue, StringComparer.OrdinalIgnoreCase), $"Expected '{expected}' to be a value in enumerator {@enum.Value.GetType().FullName}; detected value '{@enum.Value}'");
                     }
                     Assert.Equal(expected.GetString().ParseEnum(enumType), @enum.Value);

--- a/Gw2Sharp/WebApi/V2/Models/Characters/ItemEquipmentLocationType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/ItemEquipmentLocationType.cs
@@ -18,6 +18,6 @@ namespace Gw2Sharp
         /// <summary>
         /// The armory location.
         /// </summary>
-        Armory,
+        Armory
     }
 }

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpRatingType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpRatingType.cs
@@ -1,3 +1,5 @@
+using System.Runtime.Serialization;
+
 namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
@@ -23,6 +25,13 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// Unranked.
         /// </summary>
-        Unranked
+        Unranked,
+
+        /// <summary>
+        /// 2v2 ranked.
+        /// "2v2Ranked" in the API, but named differently in Gw2Sharp due to technical limitations.
+        /// </summary>
+        [EnumMember(Value = "2v2Ranked")]
+        TwoVTwoRanked
     }
 }


### PR DESCRIPTION
This new enum value was added some time ago.
It's named as `TwoVTwoRanked` in the enum, because of C# limitations.

I also fixed the tests where it checks if the given enum values of a JSON test file, all exist in the respective enum definition. Deserializing went okay, because it already checked the `EnumMemberAttribute`, however the test did not.

Need to follow up on #52 for a possible performance bottleneck I noticed.