### PR TITLE
Swap GitVersion to action to fix set-env support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Create assembly info file for GitVersion
         shell: powershell
         run: |
-          New-Item -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -ItemType File
+          set-Content -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -Value 'using System.Reflection;'
       - uses: gittools/actions/gitversion/setup@v0.9.6
         with:
           versionSpec: '5.x'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         shell: powershell
         run: |
           New-Item -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -ItemType File
-      - uses: gittools/actions/gitversion/setup/v0.9.6
+      - uses: gittools/actions/gitversion/setup@v0.9.6
         with:
           versionSpec: '5.x'
       - uses: gittools/actions/gitversion/execute@v0.9.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,25 +43,27 @@ jobs:
       - name: Install InheritDocTool
         shell: powershell
         run: dotnet tool install --global InheritDocTool
-      - name: Patch nightly version
+      # GitVersion action doesn't support /ensureassemblyinfo, see https://github.com/GitTools/actions/issues/220
+      # So we need to create a new file to let GitVersion populate it
+      - name: Create assembly info file for GitVersion
         shell: powershell
         run: |
-          $version = GitVersion /output json /updateassemblyinfo Gw2Sharp/Properties/AssemblyVersionInfo.cs /ensureassemblyinfo
-          Write-Output $version
-          $version = $version | ConvertFrom-Json
-          $nuget = $version.SemVer
-          Write-Output "Assembly version: $($version.AssemblySemVer)"
-          Write-Output "Assembly file version: $($version.AssemblySemFileVer)"
-          Write-Output "Informational version: $($version.InformationalVersion)"
-          Write-Output "NuGet version: $nuget"
-          echo "::set-env name=VERSION::$nuget"
+          New-Item -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -ItemType File
+      - uses: gittools/actions/gitversion/setup/v0.9.6
+        with:
+          versionSpec: '5.x'
+      - uses: gittools/actions/gitversion/execute@v0.9.6
+        id: gitversion
+        with:
+          updateAssemblyInfo: true
+          updateAssemblyInfoFilename: Gw2Sharp/Properties/AssemblyVersionInfo.cs
       - name: Run dotnet build
-        run: dotnet build -c Release -p:VERSIONED_BUILD=$env:VERSION
+        run: dotnet build -c Release -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Run InheritDocTool
         shell: powershell
         run: InheritDoc -o
       - name: Run dotnet pack
-        run: dotnet pack Gw2Sharp -c Release --no-build -p:VERSIONED_BUILD=$env:VERSION
+        run: dotnet pack Gw2Sharp -c Release --no-build -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Run dotnet nuget push
         run: |
           dotnet nuget add source https://pkgs.dev.azure.com/Archomeda/Gw2Sharp/_packaging/Nightly/nuget/v3/index.json -n AzureDevOps -u github-actions -p "${{ secrets.DEVOPS_TOKEN }}"

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Create assembly info file for GitVersion
         shell: powershell
         run: |
-          New-Item -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -ItemType File
+          set-Content -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -Value 'using System.Reflection;'
       - uses: gittools/actions/gitversion/setup@v0.9.6
         with:
           versionSpec: '5.x'

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -38,18 +38,22 @@ jobs:
       - name: Install InheritDocTool
         shell: powershell
         run: dotnet tool install --global InheritDocTool
-      - name: Patch release version
+      # GitVersion action doesn't support /ensureassemblyinfo, see https://github.com/GitTools/actions/issues/220
+      # So we need to create a new file to let GitVersion populate it
+      - name: Create assembly info file for GitVersion
         shell: powershell
         run: |
-          $version = GitVersion /output json /updateassemblyinfo Gw2Sharp/Properties/AssemblyVersionInfo.cs /ensureassemblyinfo | ConvertFrom-Json
-          $nuget = $version.SemVer
-          Write-Output "Assembly version: $($version.AssemblySemVer)"
-          Write-Output "Assembly file version: $($version.AssemblySemFileVer)"
-          Write-Output "Informational version: $($version.InformationalVersion)"
-          Write-Output "NuGet version: $nuget"
-          echo "::set-env name=VERSION::$nuget"
+          New-Item -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -ItemType File
+      - uses: gittools/actions/gitversion/setup/v0.9.6
+        with:
+          versionSpec: '5.x'
+      - uses: gittools/actions/gitversion/execute@v0.9.6
+        id: gitversion
+        with:
+          updateAssemblyInfo: true
+          updateAssemblyInfoFilename: Gw2Sharp/Properties/AssemblyVersionInfo.cs
       - name: Run dotnet build
-        run: dotnet build -c Release -p:VERSIONED_BUILD=${{ env.VERSION }}
+        run: dotnet build -c Release -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }}
       - name: Run InheritDocTool
         shell: powershell
         run: InheritDoc -o
@@ -57,7 +61,7 @@ jobs:
         shell: powershell
         run: 7z a Gw2Sharp.zip ./Gw2Sharp/bin/Release/*
       - name: Run dotnet pack
-        run: dotnet pack Gw2Sharp -c Release --no-build --include-symbols -p:SymbolPackageFormat=snupkg -p:VERSIONED_BUILD=${{ env.VERSION }} -o pack
+        run: dotnet pack Gw2Sharp -c Release --no-build --include-symbols -p:SymbolPackageFormat=snupkg -p:VERSIONED_BUILD=${{ steps.gitversion.outputs.semVer }} -o pack
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -44,7 +44,7 @@ jobs:
         shell: powershell
         run: |
           New-Item -Path Gw2Sharp/Properties/AssemblyVersionInfo.cs -ItemType File
-      - uses: gittools/actions/gitversion/setup/v0.9.6
+      - uses: gittools/actions/gitversion/setup@v0.9.6
         with:
           versionSpec: '5.x'
       - uses: gittools/actions/gitversion/execute@v0.9.6


### PR DESCRIPTION
Support for set-env support has been removed last week, causing CI failures.
This will change to GitVersion's action instead of using our own PowerShell script to version the built assemblies, which also doesn't use set-env anymore.

https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/
