### PR TITLE
Skip SonarCloud in PRs from forked repos

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,6 +9,7 @@ jobs:
   sonarcloud:
     name: Analysis
     runs-on: windows-latest
+    if: github.repository == 'Archomeda/Gw2Sharp'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Forked repositories don't have access to the SonarCloud secret, therefore always failing the check.
This will (hopefully) skip the check.