### PR TITLE
Update to the latest character schema for equipment_pvp changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Gw2Sharp History
 
+## 1.1.0 (8 April 2021)
+This release applies the schema changes of 2021-04-06, which has moved the PvP equipment details to the proper equipment tabs information.
+
+### Endpoints
+- Move `EquipmentPvp` from `Gw2Sharp.WebApi.V2.Models.Character` to `Gw2Sharp.WebApi.V2.Models.CharacterEquipmentTabSlot` ([#85](https://github.com/Archomeda/Gw2Sharp/issues/85)).
+  - This deprecates `EquipmentPvp` from `Gw2Sharp.WebApi.V2.Models.Character` and will finally be removed from Gw2Sharp starting from version 2.0
+  - This makes `EquipmentPvp` also available under the `/v2/characters/:id/equipmenttabs` sub-endpoint, which can be reached from [`Gw2Client.WebApi.V2.Characters[id].EquipmentTabs`](https://archomeda.github.io/Gw2Sharp/master/api/Gw2Sharp.WebApi.V2.Clients.CharactersIdEquipmentTabsClient.html)
+
+---
+
 ## 1.0.0 (1 January 2021)
 *Gw2Sharp can now be considered feature complete.*
 

--- a/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
+++ b/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
@@ -65,6 +65,8 @@
     <None Remove="TestFiles\Backstory\BackstoryQuestions.single.json" />
     <None Remove="TestFiles\Build\Build.json" />
     <None Remove="TestFiles\Characters\Characters.bulk.json" />
+    <None Remove="TestFiles\Characters\Characters.EquipmentTabs.json" />
+    <None Remove="TestFiles\Characters\Characters.EquipmentTabs.Null.json" />
     <None Remove="TestFiles\Characters\Characters.ids.json" />
     <None Remove="TestFiles\Characters\Characters.single.json" />
     <None Remove="TestFiles\Characters\CharactersIdBackstory.json" />
@@ -362,6 +364,8 @@
     <EmbeddedResource Include="TestFiles\Backstory\BackstoryQuestions.ids.json" />
     <EmbeddedResource Include="TestFiles\Backstory\BackstoryQuestions.single.json" />
     <EmbeddedResource Include="TestFiles\Build\Build.json" />
+    <EmbeddedResource Include="TestFiles\Characters\Characters.EquipmentTabs.json" />
+    <EmbeddedResource Include="TestFiles\Characters\Characters.EquipmentTabs.Null.json" />
     <EmbeddedResource Include="TestFiles\Characters\Characters.bulk.json" />
     <EmbeddedResource Include="TestFiles\Characters\Characters.ids.json" />
     <EmbeddedResource Include="TestFiles\Characters\Characters.single.json" />

--- a/Gw2Sharp.Tests/TestFiles/Characters/Characters.EquipmentTabs.Null.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/Characters.EquipmentTabs.Null.json
@@ -1,0 +1,339 @@
+{
+  "name": "Bob",
+  "race": "Human",
+  "gender": "Male",
+  "flags": [
+
+  ],
+  "profession": "Warrior",
+  "level": 80,
+  "guild": "F00FF00F-F00F-F00F-F00F-F00FF00FF00F",
+  "age": 7441000,
+  "last_modified": "2019-05-22T22:51:00Z",
+  "created": "2014-01-31T18:00:00Z",
+  "deaths": 4100,
+  "crafting": [
+    {
+      "discipline": "Armorsmith",
+      "rating": 500,
+      "active": true
+    },
+    {
+      "discipline": "Weaponsmith",
+      "rating": 500,
+      "active": true
+    }
+  ],
+  "title": 225,
+  "backstory": [
+    "1-2",
+    "3-4",
+    "5-6",
+    "7-8",
+    "9-10"
+  ],
+  "wvw_abilities": [
+    {
+      "id": 1,
+      "rank": 4
+    },
+    {
+      "id": 2,
+      "rank": 5
+    }
+  ],
+  "recipes": [
+    1,
+    2,
+    3,
+    4
+  ],
+  "training": [
+    {
+      "id": 72,
+      "spent": 22,
+      "done": true
+    },
+    {
+      "id": 76,
+      "spent": 24,
+      "done": true
+    },
+    {
+      "id": 50,
+      "spent": 15,
+      "done": true
+    },
+    {
+      "id": 64,
+      "spent": 15,
+      "done": true
+    },
+    {
+      "id": 117,
+      "spent": 22,
+      "done": true
+    },
+    {
+      "id": 27,
+      "spent": 60,
+      "done": true
+    },
+    {
+      "id": 87,
+      "spent": 60,
+      "done": true
+    },
+    {
+      "id": 109,
+      "spent": 10,
+      "done": false
+    },
+    {
+      "id": 55,
+      "spent": 60,
+      "done": true
+    }
+  ],
+  "bags": [
+    {
+      "id": 8932,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 48715,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 19620,
+          "count": 1,
+          "binding": "Character",
+          "bound_to": "Bob"
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 48715,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 48715,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 9594,
+      "size": 20,
+      "inventory": [
+        {
+          "id": 85016,
+          "count": 250
+        },
+        null,
+        {
+          "id": 85016,
+          "count": 93
+        },
+        null,
+        {
+          "id": 84731,
+          "count": 98
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 73653,
+          "count": 6,
+          "binding": "Account"
+        },
+        null,
+        {
+          "id": 24836,
+          "count": 6
+        },
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 78963,
+          "count": 1,
+          "skin": 5871,
+          "upgrades": [
+            24615
+          ],
+          "binding": "Account",
+          "stats": {
+            "id": 161,
+            "attributes": {
+              "Power": 125,
+              "Precision": 90,
+              "CritDamage": 90
+            }
+          }
+        },
+        {
+          "id": 46759,
+          "count": 1,
+          "skin": 5871,
+          "upgrades": [
+            24618
+          ],
+          "binding": "Account"
+        }
+      ]
+    },
+    {
+      "id": 87225,
+      "size": 32,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 87695,
+          "count": 1,
+          "binding": "Character",
+          "bound_to": "Bob"
+        },
+        {
+          "id": 88023,
+          "count": 1,
+          "binding": "Account"
+        },
+        {
+          "id": 87630,
+          "count": 72,
+          "binding": "Account"
+        },
+        {
+          "id": 86793,
+          "count": 1,
+          "binding": "Account"
+        },
+        {
+          "id": 87517,
+          "count": 8,
+          "binding": "Account"
+        },
+        {
+          "id": 79626,
+          "count": 1,
+          "binding": "Character",
+          "bound_to": "Bob"
+        }
+      ]
+    }
+  ]
+}

--- a/Gw2Sharp.Tests/TestFiles/Characters/Characters.EquipmentTabs.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/Characters.EquipmentTabs.json
@@ -1,0 +1,660 @@
+{
+  "name": "Bob",
+  "race": "Human",
+  "gender": "Male",
+  "flags": [
+
+  ],
+  "profession": "Warrior",
+  "level": 80,
+  "guild": "F00FF00F-F00F-F00F-F00F-F00FF00FF00F",
+  "age": 7441000,
+  "last_modified": "2019-05-22T22:51:00Z",
+  "created": "2014-01-31T18:00:00Z",
+  "deaths": 4100,
+  "crafting": [
+    {
+      "discipline": "Armorsmith",
+      "rating": 500,
+      "active": true
+    },
+    {
+      "discipline": "Weaponsmith",
+      "rating": 500,
+      "active": true
+    }
+  ],
+  "title": 225,
+  "backstory": [
+    "1-2",
+    "3-4",
+    "5-6",
+    "7-8",
+    "9-10"
+  ],
+  "wvw_abilities": [
+    {
+      "id": 1,
+      "rank": 4
+    },
+    {
+      "id": 2,
+      "rank": 5
+    }
+  ],
+  "build_tabs_unlocked": 1,
+  "active_build_tab": 1,
+  "build_tabs": [
+    {
+      "tab": 1,
+      "is_active": true,
+      "build": {
+        "name": "Non-existent warrior build",
+        "profession": "Warrior",
+        "specializations": [
+          {
+            "id": 36,
+            "traits": [
+              1455,
+              1333,
+              1346
+            ]
+          },
+          {
+            "id": 11,
+            "traits": [
+              1471,
+              1482,
+              1667
+            ]
+          },
+          {
+            "id": 18,
+            "traits": [
+              2039,
+              2042,
+              2038
+            ]
+          }
+        ],
+        "skills": {
+          "heal": 30189,
+          "utilities": [
+            30074,
+            14405,
+            14407
+          ],
+          "elite": 30343
+        },
+        "aquatic_skills": {
+          "heal": 22222,
+          "utilities": [
+            33333,
+            44444,
+            55555
+          ],
+          "elite": null
+        }
+      }
+    }
+  ],
+  "equipment_tabs_unlocked": 1,
+  "active_equipment_tab": 1,
+  "equipment_tabs": [
+    {
+      "tab": 1,
+      "is_active": true,
+      "equipment": [
+        {
+          "id": 6479,
+          "slot": "HelmAquatic",
+          "binding": "Character",
+          "bound_to": "Bob"
+        },
+        {
+          "id": 77474,
+          "slot": "Backpack",
+          "infusions": [
+            78052,
+            78028
+          ],
+          "skin": 2352,
+          "stats": {
+            "id": 1130,
+            "attributes": {
+              "Power": 52,
+              "Precision": 27,
+              "ConditionDamage": 52,
+              "ConditionDuration": 27
+            }
+          },
+          "binding": "Account"
+        },
+        {
+          "id": 80254,
+          "slot": "Coat",
+          "upgrades": [
+            83502
+          ],
+          "infusions": [
+            70852
+          ],
+          "stats": {
+            "id": 1153,
+            "attributes": {
+              "Power": 121,
+              "Precision": 67,
+              "ConditionDamage": 121,
+              "ConditionDuration": 67
+            }
+          },
+          "binding": "Account",
+          "dyes": [
+            11,
+            1155,
+            6,
+            null
+          ]
+        },
+        {
+          "id": 80557,
+          "slot": "Boots",
+          "upgrades": [
+            83502
+          ],
+          "infusions": [
+            70852
+          ],
+          "stats": {
+            "id": 1153,
+            "attributes": {
+              "Power": 40,
+              "Precision": 22,
+              "ConditionDamage": 40,
+              "ConditionDuration": 22
+            }
+          },
+          "binding": "Account",
+          "dyes": [
+            11,
+            1155,
+            6,
+            null
+          ]
+        },
+        {
+          "id": 78984,
+          "slot": "WeaponA1",
+          "upgrades": [
+            24605
+          ],
+          "infusions": [
+            49432
+          ],
+          "skin": 6588,
+          "stats": {
+            "id": 1224,
+            "attributes": {
+              "Power": 108,
+              "Precision": 59,
+              "ConditionDamage": 108,
+              "ConditionDuration": 59
+            }
+          },
+          "binding": "Account"
+        },
+        {
+          "id": 49308,
+          "slot": "Sickle",
+          "binding": "Account"
+        },
+        {
+          "id": 48931,
+          "slot": "Axe",
+          "skin": 8087,
+          "binding": "Account"
+        },
+        {
+          "id": 87422,
+          "slot": "Pick",
+          "skin": 8097,
+          "binding": "Account"
+        }
+      ],
+      "equipment_pvp": {
+        "amulet": 14,
+        "rune": 21172,
+        "sigils": [
+          21152,
+          21150,
+          21152,
+          null
+        ]
+      }
+    }
+  ],
+  "equipment": [
+    {
+      "id": 6479,
+      "location": "Equipped",
+      "slot": "HelmAquatic",
+      "tabs": [ 1 ],
+      "binding": "Character",
+      "bound_to": "Bob"
+    },
+    {
+      "id": 77474,
+      "location": "Equipped",
+      "slot": "Backpack",
+      "tabs": [ 1 ],
+      "infusions": [
+        78052,
+        78028
+      ],
+      "skin": 2352,
+      "stats": {
+        "id": 1130,
+        "attributes": {
+          "Power": 52,
+          "Precision": 27,
+          "ConditionDamage": 52,
+          "ConditionDuration": 27
+        }
+      },
+      "binding": "Account"
+    },
+    {
+      "id": 80254,
+      "location": "Equipped",
+      "slot": "Coat",
+      "tabs": [ 1 ],
+      "upgrades": [
+        83502
+      ],
+      "infusions": [
+        70852
+      ],
+      "stats": {
+        "id": 1153,
+        "attributes": {
+          "Power": 121,
+          "Precision": 67,
+          "ConditionDamage": 121,
+          "ConditionDuration": 67
+        }
+      },
+      "binding": "Account",
+      "dyes": [
+        11,
+        1155,
+        6,
+        null
+      ]
+    },
+    {
+      "id": 80557,
+      "location": "Equipped",
+      "slot": "Boots",
+      "tabs": [ 1 ],
+      "upgrades": [
+        83502
+      ],
+      "infusions": [
+        70852
+      ],
+      "stats": {
+        "id": 1153,
+        "attributes": {
+          "Power": 40,
+          "Precision": 22,
+          "ConditionDamage": 40,
+          "ConditionDuration": 22
+        }
+      },
+      "binding": "Account",
+      "dyes": [
+        11,
+        1155,
+        6,
+        null
+      ]
+    },
+    {
+      "id": 78984,
+      "location": "Equipped",
+      "slot": "WeaponA1",
+      "tabs": [ 1 ],
+      "upgrades": [
+        24605
+      ],
+      "infusions": [
+        49432
+      ],
+      "skin": 6588,
+      "stats": {
+        "id": 1224,
+        "attributes": {
+          "Power": 108,
+          "Precision": 59,
+          "ConditionDamage": 108,
+          "ConditionDuration": 59
+        }
+      },
+      "binding": "Account"
+    },
+    {
+      "id": 49308,
+      "location": "Equipped",
+      "slot": "Sickle",
+      "binding": "Account"
+    },
+    {
+      "id": 48931,
+      "location": "Equipped",
+      "slot": "Axe",
+      "skin": 8087,
+      "binding": "Account"
+    },
+    {
+      "id": 87422,
+      "location": "Equipped",
+      "slot": "Pick",
+      "skin": 8097,
+      "binding": "Account"
+    }
+  ],
+  "recipes": [
+    1,
+    2,
+    3,
+    4
+  ],
+  "training": [
+    {
+      "id": 72,
+      "spent": 22,
+      "done": true
+    },
+    {
+      "id": 76,
+      "spent": 24,
+      "done": true
+    },
+    {
+      "id": 50,
+      "spent": 15,
+      "done": true
+    },
+    {
+      "id": 64,
+      "spent": 15,
+      "done": true
+    },
+    {
+      "id": 117,
+      "spent": 22,
+      "done": true
+    },
+    {
+      "id": 27,
+      "spent": 60,
+      "done": true
+    },
+    {
+      "id": 87,
+      "spent": 60,
+      "done": true
+    },
+    {
+      "id": 109,
+      "spent": 10,
+      "done": false
+    },
+    {
+      "id": 55,
+      "spent": 60,
+      "done": true
+    }
+  ],
+  "bags": [
+    {
+      "id": 8932,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 48715,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 19620,
+          "count": 1,
+          "binding": "Character",
+          "bound_to": "Bob"
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 48715,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 48715,
+      "size": 20,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ]
+    },
+    {
+      "id": 9594,
+      "size": 20,
+      "inventory": [
+        {
+          "id": 85016,
+          "count": 250
+        },
+        null,
+        {
+          "id": 85016,
+          "count": 93
+        },
+        null,
+        {
+          "id": 84731,
+          "count": 98
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 73653,
+          "count": 6,
+          "binding": "Account"
+        },
+        null,
+        {
+          "id": 24836,
+          "count": 6
+        },
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 78963,
+          "count": 1,
+          "skin": 5871,
+          "upgrades": [
+            24615
+          ],
+          "binding": "Account",
+          "stats": {
+            "id": 161,
+            "attributes": {
+              "Power": 125,
+              "Precision": 90,
+              "CritDamage": 90
+            }
+          }
+        },
+        {
+          "id": 46759,
+          "count": 1,
+          "skin": 5871,
+          "upgrades": [
+            24618
+          ],
+          "binding": "Account"
+        }
+      ]
+    },
+    {
+      "id": 87225,
+      "size": 32,
+      "inventory": [
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        {
+          "id": 87695,
+          "count": 1,
+          "binding": "Character",
+          "bound_to": "Bob"
+        },
+        {
+          "id": 88023,
+          "count": 1,
+          "binding": "Account"
+        },
+        {
+          "id": 87630,
+          "count": 72,
+          "binding": "Account"
+        },
+        {
+          "id": 86793,
+          "count": 1,
+          "binding": "Account"
+        },
+        {
+          "id": 87517,
+          "count": 8,
+          "binding": "Account"
+        },
+        {
+          "id": 79626,
+          "count": 1,
+          "binding": "Character",
+          "bound_to": "Bob"
+        }
+      ]
+    }
+  ]
+}

--- a/Gw2Sharp.Tests/TestFiles/Characters/Characters.single.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/Characters.single.json
@@ -220,7 +220,17 @@
           "skin": 8097,
           "binding": "Account"
         }
-      ]
+      ],
+      "equipment_pvp": {
+        "amulet": 14,
+        "rune": 21172,
+        "sigils": [
+          21152,
+          21150,
+          21152,
+          null
+        ]
+      }
     }
   ],
   "equipment": [
@@ -359,16 +369,6 @@
     3,
     4
   ],
-  "equipment_pvp": {
-    "amulet": 14,
-    "rune": 21172,
-    "sigils": [
-      21152,
-      21150,
-      21152,
-      null
-    ]
-  },
   "training": [
     {
       "id": 72,

--- a/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.bulk.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.bulk.json
@@ -111,7 +111,17 @@
         },
         "binding": "Account"
       }
-    ]
+    ],
+    "equipment_pvp": {
+      "amulet": 14,
+      "rune": 21172,
+      "sigils": [
+        21152,
+        21150,
+        21152,
+        null
+      ]
+    }
   },
   {
     "tab": 2,
@@ -200,6 +210,16 @@
         "binding": "Character",
         "bound_to": "Bob"
       }
-    ]
+    ],
+    "equipment_pvp": {
+      "amulet": 14,
+      "rune": 21172,
+      "sigils": [
+        21152,
+        21150,
+        21152,
+        null
+      ]
+    }
   }
 ]

--- a/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.single.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.single.json
@@ -110,5 +110,15 @@
       },
       "binding": "Account"
     }
-  ]
+  ],
+  "equipment_pvp": {
+    "amulet": 14,
+    "rune": 21172,
+    "sigils": [
+      21152,
+      21150,
+      21152,
+      null
+    ]
+  }
 }

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
@@ -70,7 +70,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
 
         #region Request Assertions
 
-        protected virtual async Task AssertPaginatedDataAsync<TObject>(IPaginatedClient<TObject> client, string file)
+        protected virtual async Task<IApiV2ObjectList<TObject>> AssertPaginatedDataAsync<TObject>(IPaginatedClient<TObject> client, string file)
             where TObject : IApiV2Object
         {
             (string data, var expected) = this.GetTestData(file);
@@ -87,9 +87,10 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var actual = await client.PageAsync(2, 100);
             this.AssertJsonObject(expected.RootElement, actual);
             this.AssertResponseInfo(actual);
+            return actual;
         }
 
-        protected virtual async Task AssertBlobDataAsync<TObject>(IBlobClient<TObject> client, string file)
+        protected virtual async Task<TObject> AssertBlobDataAsync<TObject>(IBlobClient<TObject> client, string file)
             where TObject : IApiV2Object
         {
             (string data, var expected) = this.GetTestData(file);
@@ -105,9 +106,10 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var actual = await client.GetAsync();
             this.AssertJsonObject(expected.RootElement, actual!);
             this.AssertResponseInfo(actual);
+            return actual;
         }
 
-        protected virtual async Task AssertGetDataAsync<TObject, TId>(IBulkExpandableClient<TObject, TId> client, string file, string idName = "id")
+        protected virtual async Task<TObject> AssertGetDataAsync<TObject, TId>(IBulkExpandableClient<TObject, TId> client, string file, string idName = "id")
             where TObject : IApiV2Object, IIdentifiable<TId>
         {
             (string data, var expected) = this.GetTestData(file);
@@ -129,9 +131,10 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var actual = await client.GetAsync(id);
             this.AssertJsonObject(expected.RootElement, actual);
             this.AssertResponseInfo(actual);
+            return actual;
         }
 
-        protected virtual async Task AssertAllDataAsync<TObject>(IAllExpandableClient<TObject> client, string file, string idsName = "ids")
+        protected virtual async Task<IApiV2ObjectList<TObject>> AssertAllDataAsync<TObject>(IAllExpandableClient<TObject> client, string file, string idsName = "ids")
             where TObject : IApiV2Object
         {
             (string data, var expected) = this.GetTestData(file);
@@ -147,9 +150,10 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var actual = await client.AllAsync();
             this.AssertJsonObject(expected.RootElement, actual);
             this.AssertResponseInfo(actual);
+            return actual;
         }
 
-        protected virtual async Task AssertBulkDataAsync<TObject, TId>(IBulkExpandableClient<TObject, TId> client, string file, string idName = "id", string idsName = "ids")
+        protected virtual async Task<IReadOnlyList<TObject>> AssertBulkDataAsync<TObject, TId>(IBulkExpandableClient<TObject, TId> client, string file, string idName = "id", string idsName = "ids")
             where TObject : IApiV2Object, IIdentifiable<TId>
         {
             (string data, var expected) = this.GetTestData(file);
@@ -175,9 +179,10 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var actual = await client.ManyAsync(ids);
             this.AssertJsonObject(expected.RootElement, actual);
             this.AssertResponseInfoList(actual);
+            return actual;
         }
 
-        protected virtual async Task AssertIdsDataAsync<TObject, TId>(IBulkExpandableClient<TObject, TId> client, string file)
+        protected virtual async Task<IApiV2ObjectList<TId>> AssertIdsDataAsync<TObject, TId>(IBulkExpandableClient<TObject, TId> client, string file)
             where TObject : IApiV2Object, IIdentifiable<TId>
         {
             (string data, var expected) = this.GetTestData(file);
@@ -194,6 +199,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
             var actual = await client.IdsAsync();
             this.AssertJsonObject(expected.RootElement, actual);
             this.AssertResponseInfo(actual);
+            return actual;
         }
 
         protected virtual void AssertRequest(CallInfo callInfo, IEndpointClient client, string pathAndQuery)

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/Characters/CharactersClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/Characters/CharactersClientTests.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Gw2Sharp.WebApi.V2.Clients;
 using Xunit;
 
@@ -30,5 +32,14 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
         [Theory]
         [InlineData("TestFiles.Characters.Characters.ids.json")]
         public Task IdsTestAsync(string file) => this.AssertIdsDataAsync(this.Client, file);
+
+        [Theory]
+        [InlineData("TestFiles.Characters.Characters.single.json")]
+        public async Task EquipmentPvpRollForwardTest(string file)
+        {
+            // This roll-forward capability will be removed from Gw2Sharp starting with version 2.0
+            var actual = await this.AssertGetDataAsync(this.Client, file, "name");
+            actual.EquipmentPvp.Should().BeEquivalentTo(actual.EquipmentTabs.Single(x => x.Tab == actual.ActiveEquipmentTab).EquipmentPvp);
+        }
     }
 }

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/Characters/CharactersClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/Characters/CharactersClientTests.cs
@@ -33,13 +33,16 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
         [InlineData("TestFiles.Characters.Characters.ids.json")]
         public Task IdsTestAsync(string file) => this.AssertIdsDataAsync(this.Client, file);
 
+#pragma warning disable CS0618
         [Theory]
-        [InlineData("TestFiles.Characters.Characters.single.json")]
+        [InlineData("TestFiles.Characters.Characters.EquipmentTabs.json")]
+        [InlineData("TestFiles.Characters.Characters.EquipmentTabs.Null.json")]
         public async Task EquipmentPvpRollForwardTest(string file)
         {
             // This roll-forward capability will be removed from Gw2Sharp starting with version 2.0
             var actual = await this.AssertGetDataAsync(this.Client, file, "name");
-            actual.EquipmentPvp.Should().BeEquivalentTo(actual.EquipmentTabs.Single(x => x.Tab == actual.ActiveEquipmentTab).EquipmentPvp);
+            actual.EquipmentPvp.Should().BeEquivalentTo(actual.EquipmentTabs?.Single(x => x.Tab == actual.ActiveEquipmentTab).EquipmentPvp);
         }
+#pragma warning restore CS0618
     }
 }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersClient.cs
@@ -8,7 +8,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// </summary>
     [EndpointPath("characters")]
     [EndpointBulkIdName("name")]
-    [EndpointSchemaVersion("2019-12-19T00:00:00.000Z")]
+    [EndpointSchemaVersion("2021-04-06T21:00:00.000Z")]
     public class CharactersClient : BaseEndpointBulkAllClient<Character, string>, ICharactersClient
     {
         /// <summary>
@@ -18,7 +18,8 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
         protected internal CharactersClient(IConnection connection, IGw2Client gw2Client) :
-            base(connection, gw2Client) { }
+            base(connection, gw2Client)
+        { }
 
         /// <inheritdoc />
         public virtual ICharactersIdClient this[string characterName] => new CharactersIdClient(this.Connection, this.Gw2Client!, characterName);

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsActiveClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsActiveClient.cs
@@ -7,7 +7,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// A client of the Guild Wars 2 API v2 characters id equipment tabs active client.
     /// </summary>
     [EndpointPath("characters/:id/equipmenttabs/active")]
-    [EndpointSchemaVersion("2019-12-19T00:00:00.000Z")]
+    [EndpointSchemaVersion("2021-04-06T21:00:00.000Z")]
     public class CharactersIdEquipmentTabsActiveClient : BaseCharactersSubBlobClient<CharacterEquipmentTabSlot>, ICharactersIdEquipmentTabsActiveClient
     {
         /// <summary>

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsClient.cs
@@ -8,7 +8,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// </summary>
     [EndpointPath("characters/:id/equipmenttabs")]
     [EndpointBulkIdName("tab", "tabs", "tab")]
-    [EndpointSchemaVersion("2019-12-19T00:00:00.000Z")]
+    [EndpointSchemaVersion("2021-04-06T21:00:00.000Z")]
     public class CharactersIdEquipmentTabsClient : BaseCharactersSubBulkClient<CharacterEquipmentTabSlot, int>, ICharactersIdEquipmentTabsClient
     {
         private readonly ICharactersIdEquipmentTabsActiveClient active;

--- a/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Gw2Sharp.WebApi.V2.Clients;
 
 namespace Gw2Sharp.WebApi.V2.Models
@@ -162,7 +163,11 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// Additionally requires scopes: builds.
         /// If the required scopes are not met, this value is <c>null</c>.
         /// </summary>
-        public CharacterEquipmentPvp? EquipmentPvp { get; set; }
+        [Obsolete("Deprecated since schema version 2021-04-06T21:00:00.000Z. Use EquipmentTabs[i].EquipmentPvp instead. This will be removed from Gw2Sharp starting from version 2.0.")]
+        public CharacterEquipmentPvp? EquipmentPvp =>
+            // Instead of using the old schema version to pull this information while also supporting the latest schema,
+            // we emulate the migration roll-forward ability ourselves by grabbing the current active tab information.
+            this.EquipmentTabs?.FirstOrDefault(x => x.Tab == this.ActiveEquipmentTab)?.EquipmentPvp;
 
         /// <summary>
         /// The list of character trainings.

--- a/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentTabSlot.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentTabSlot.cs
@@ -30,5 +30,12 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// The equipment.
         /// </summary>
         public IReadOnlyList<CharacterEquipmentItem> Equipment { get; set; } = Array.Empty<CharacterEquipmentItem>();
+
+        /// <summary>
+        /// The PvP equipment.
+        /// Additionally requires scopes: builds.
+        /// If the required scopes are not met, this value is <c>null</c>.
+        /// </summary>
+        public CharacterEquipmentPvp? EquipmentPvp { get; set; }
     }
 }

--- a/docs/guides/endpoints.md
+++ b/docs/guides/endpoints.md
@@ -75,7 +75,7 @@ For your convenience, the following list gives an overview of the web API endpoi
  /v2/characters/`:id`/crafting | 🔑📆 | [`Gw2Client.WebApi.V2.Characters[id].Crafting`](../api/Gw2Sharp.WebApi.V2.Clients.CharactersIdCraftingClient.html)
  ~~/v2/characters/`:id`/dungeons~~ | ✖️ |
  /v2/characters/`:id`/equipment | 🔑📆 | [`Gw2Client.WebApi.V2.Characters[id].Equipment`](../api/Gw2Sharp.WebApi.V2.Clients.CharactersIdEquipmentClient.html)
- /v2/characters/`:id`/equipmenttabs | 🔑 | [`Gw2Client.WebApi.V2.Characters[id].EquipmentTabs`](../api/Gw2Sharp.WebApi.V2.Clients.CharactersIdEquipmentTabsActiveClient.html)
+ /v2/characters/`:id`/equipmenttabs | 🔑 | [`Gw2Client.WebApi.V2.Characters[id].EquipmentTabs`](../api/Gw2Sharp.WebApi.V2.Clients.CharactersIdEquipmentTabsClient.html)
  /v2/characters/`:id`/equipmenttabs/active | 🔑 | [`Gw2Client.WebApi.V2.Characters[id].EquipmentTabs.Active`](../api/Gw2Sharp.WebApi.V2.Clients.CharactersIdEquipmentTabsActiveClient.html)
  /v2/characters/`:id`/heropoints | 🔑 | [`Gw2Client.WebApi.V2.Characters[id].HeroPoints`](../api/Gw2Sharp.WebApi.V2.Clients.CharactersIdHeroPointsClient.html)
  /v2/characters/`:id`/inventory | 🔑📆 | [`Gw2Client.WebApi.V2.Characters[id].Inventory`](../api/Gw2Sharp.WebApi.V2.Clients.CharactersIdInventoryClient.html)


### PR DESCRIPTION
The `2021-04-06T21:00:00.000Z` schema has moved the PvP equipment under the `equipment_tabs` property.
This PR reflects that change, with automatic rollforward from the now deprecated `equipment_pvp` under the root character object.