### PR TITLE
Fix documentation exception links

### DIFF
--- a/docs/guides/exception-handling.md
+++ b/docs/guides/exception-handling.md
@@ -8,21 +8,21 @@ Gw2Sharp aims to be as friendly as possible when unexpected status codes are rec
 Whenever a request fails, a custom exception will be thrown for you to catch.
 
 The following exceptions can be thrown from Gw2Sharp:
-- [`RequestException`](../api/Gw2Sharp.WebApi.Http.RequestException.html): An exception occured during the request
-  - [`RequestCanceledException`](../api/Gw2Sharp.WebApi.Http.RequestCanceledException.html): The request has been canceled
-  - [`UnexpectedStatusException`](../api/Gw2Sharp.WebApi.Http.UnexpectedStatusException.html): An unexpected HTTP status code was returned from the server
-    - [`BadRequestException`](../api/Gw2Sharp.WebApi.Http.BadRequestException.html) (400): The client sent an invalid request
-      - [`ListTooLongException`](../api/Gw2Sharp.WebApi.Http.ListTooLongException.html) (400): The list of requested resources is too long
-      - [`PageOutOfRangeException`](../api/Gw2Sharp.WebApi.Http.PageOutOfRangeException.html) (400): The requested page is out of range
-    - [`AuthorizationRequiredException`](../api/Gw2Sharp.WebApi.Http.AuthorizationRequiredException.html) (401, 403): The client is unauthorized
-      - [`InvalidAccessTokenException`](../api/Gw2Sharp.WebApi.Http.InvalidAccessTokenException.html) (401, 403): The access token is invalid
-      - [`MissingScopesException`](../api/Gw2Sharp.WebApi.Http.MissingScopesException.html) (403): The access token does not have the required scopes
-      - [`MembershipRequiredException`](../api/Gw2Sharp.WebApi.Http.MembershipRequiredException.html) (403): The user is not a member of the guild
-      - [`RestrictedToGuildLeadersException`](../api/Gw2Sharp.WebApi.Http.RestrictedToGuildLeadersException.html) (403): The user is not a leader of the guild
-    - [`NotFoundException`](../api/Gw2Sharp.WebApi.Http.NotFoundException.html) (404): The requested resource has not been found
-    - [`TooManyRequestsException`](../api/Gw2Sharp.WebApi.Http.TooManyRequestsException.html) (429): Too many requests have been issued in a short period of time
-    - [`ServerErrorException`](../api/Gw2Sharp.WebApi.Http.ServerErrorException.html) (500): The server encountered an error
-    - [`ServiceUnavailableException`](../api/Gw2Sharp.WebApi.Http.ServiceUnavailableException.html) (503): The server is temporarily unavailable
+- [`RequestException`](../api/Gw2Sharp.WebApi.Exceptions.RequestException.html): An exception occured during the request
+  - [`RequestCanceledException`](../api/Gw2Sharp.WebApi.Exceptions.RequestCanceledException.html): The request has been canceled
+  - [`UnexpectedStatusException`](../api/Gw2Sharp.WebApi.Exceptions.UnexpectedStatusException.html): An unexpected HTTP status code was returned from the server
+    - [`BadRequestException`](../api/Gw2Sharp.WebApi.Exceptions.BadRequestException.html) (400): The client sent an invalid request
+      - [`ListTooLongException`](../api/Gw2Sharp.WebApi.Exceptions.ListTooLongException.html) (400): The list of requested resources is too long
+      - [`PageOutOfRangeException`](../api/Gw2Sharp.WebApi.Exceptions.PageOutOfRangeException.html) (400): The requested page is out of range
+    - [`AuthorizationRequiredException`](../api/Gw2Sharp.WebApi.Exceptions.AuthorizationRequiredException.html) (401, 403): The client is unauthorized
+      - [`InvalidAccessTokenException`](../api/Gw2Sharp.WebApi.Exceptions.InvalidAccessTokenException.html) (401, 403): The access token is invalid
+      - [`MissingScopesException`](../api/Gw2Sharp.WebApi.Exceptions.MissingScopesException.html) (403): The access token does not have the required scopes
+      - [`MembershipRequiredException`](../api/Gw2Sharp.WebApi.Exceptions.MembershipRequiredException.html) (403): The user is not a member of the guild
+      - [`RestrictedToGuildLeadersException`](../api/Gw2Sharp.WebApi.Exceptions.RestrictedToGuildLeadersException.html) (403): The user is not a leader of the guild
+    - [`NotFoundException`](../api/Gw2Sharp.WebApi.Exceptions.NotFoundException.html) (404): The requested resource has not been found
+    - [`TooManyRequestsException`](../api/Gw2Sharp.WebApi.Exceptions.TooManyRequestsException.html) (429): Too many requests have been issued in a short period of time
+    - [`ServerErrorException`](../api/Gw2Sharp.WebApi.Exceptions.ServerErrorException.html) (500): The server encountered an error
+    - [`ServiceUnavailableException`](../api/Gw2Sharp.WebApi.Exceptions.ServiceUnavailableException.html) (503): The server is temporarily unavailable
 
 > [!TIP]
 > As you can see, all custom exceptions inherit from `RequestException`.


### PR DESCRIPTION
The exception page in the docs has invalid links to the exception classes. They were moved some time ago, but I forgot to update these references.