### PR TITLE
Fix exception type when the result is not JSON

### DIFF
--- a/Gw2Sharp/WebApi/Middleware/ExceptionMiddleware.cs
+++ b/Gw2Sharp/WebApi/Middleware/ExceptionMiddleware.cs
@@ -53,7 +53,7 @@ namespace Gw2Sharp.WebApi.Middleware
                 catch (JsonException)
                 {
                     // Fallback message
-                    throw new UnexpectedStatusException(context.Request, httpResponse, httpResponse.Content);
+                    error = new ErrorObject { Text = httpResponse.Content };
                 }
 
                 var errorResponse = new WebApiResponse<ErrorObject>(error, httpResponse.StatusCode, httpResponse.CacheState, httpResponse.ResponseHeaders);


### PR DESCRIPTION
Failing API responses that don't have a JSON body currently throw the `UnexpectedStatusException` which is incorrect if the server responded with e.g. a 500 code. This fixes the exception type to be its proper exception type.