### PR TITLE
Add .NET 5 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         dotnet:
+          - net5.0
           - netcoreapp3.1
           - netcoreapp2.1
           - net461

--- a/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
+++ b/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Nullable>annotations</Nullable>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/Gw2Sharp.Tests/Mumble/Gw2MumbleClientTests.cs
+++ b/Gw2Sharp.Tests/Mumble/Gw2MumbleClientTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO.MemoryMappedFiles;
 using System.Reflection;
+using FluentAssertions;
 using Gw2Sharp.Models;
 using Gw2Sharp.Mumble;
 using Gw2Sharp.Mumble.Models;
@@ -10,12 +11,29 @@ namespace Gw2Sharp.Tests.Mumble
 {
     public class Gw2MumbleClientTests
     {
+        private bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+        [Fact]
+        public void ThrowsPlatformNotSupportedExceptionIfNotWindowsTest()
+        {
+            Action createClient = () =>
+            {
+                using var client = new Gw2MumbleClient();
+                client.Update();
+            };
+
+            if (this.isWindows)
+                createClient.Should().NotThrow<PlatformNotSupportedException>();
+            else
+                createClient.Should().Throw<PlatformNotSupportedException>();
+        }
+
         [SkippableFact]
         public void ReadStructCorrectlyTest()
         {
             // Named memory mapped files aren't supported on Unix based systems.
             // So we need to skip this test.
-            Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT, "Mumble Link is only supported in Windows");
+            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
 
             using var memorySource = Assembly.GetExecutingAssembly().GetManifestResourceStream($"Gw2Sharp.Tests.TestFiles.Mumble.MemoryMappedFile.bin");
             using var memoryMappedFile = MemoryMappedFile.CreateOrOpen(Gw2MumbleClient.DEFAULT_MUMBLE_LINK_MAP_NAME, memorySource.Length);
@@ -80,7 +98,7 @@ namespace Gw2Sharp.Tests.Mumble
         {
             // Named memory mapped files aren't supported on Unix based systems.
             // So we need to skip this test.
-            Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT, "Mumble Link is only supported in Windows");
+            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
 
             var client = new Gw2MumbleClient();
             client.Dispose();
@@ -92,7 +110,7 @@ namespace Gw2Sharp.Tests.Mumble
         {
             // Named memory mapped files aren't supported on Unix based systems.
             // So we need to skip this test.
-            Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT, "Mumble Link is only supported in Windows");
+            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
 
             using var rootClient = new Gw2MumbleClient();
             var childClientA = rootClient["CinderSteeltemper"];
@@ -108,7 +126,7 @@ namespace Gw2Sharp.Tests.Mumble
         {
             // Named memory mapped files aren't supported on Unix based systems.
             // So we need to skip this test.
-            Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT, "Mumble Link is only supported in Windows");
+            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
 
             var rootClient = new Gw2MumbleClient();
             var childClientA = rootClient["CinderSteeltemper"];

--- a/Gw2Sharp/ChatLinks/Gw2ChatLink.cs
+++ b/Gw2Sharp/ChatLinks/Gw2ChatLink.cs
@@ -117,7 +117,7 @@ namespace Gw2Sharp.ChatLinks
                     chatLinkString = chatLinkString.Remove(chatLinkString.Length - 1);
 
                 byte[] bytes = Convert.FromBase64String(chatLinkString);
-                var chatLink = ((ChatLinkType)bytes[0]) switch
+                var chatLink = (ChatLinkType)bytes[0] switch
                 {
                     ChatLinkType.Coin => (Gw2ChatLink)new CoinChatLink(),
                     ChatLinkType.Item => new ItemChatLink(),

--- a/Gw2Sharp/Connection.cs
+++ b/Gw2Sharp/Connection.cs
@@ -170,7 +170,7 @@ namespace Gw2Sharp
             this.Middleware.Add(new ExceptionMiddleware());
         }
 
-        private void Middleware_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        private void Middleware_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             var hashCode = new HashCode();
             foreach (var middleware in this.Middleware)

--- a/Gw2Sharp/Connection.cs
+++ b/Gw2Sharp/Connection.cs
@@ -85,7 +85,9 @@ namespace Gw2Sharp
             string userAgentProduct = "Gw2Sharp";
             try
             {
-                userAgentProduct = $"Gw2Sharp/{new Version(FileVersionInfo.GetVersionInfo(typeof(Gw2Client).Assembly.Location).FileVersion).ToString(3)}";
+                string? fileVersion = FileVersionInfo.GetVersionInfo(typeof(Gw2Client).Assembly.Location).FileVersion;
+                if (!string.IsNullOrWhiteSpace(fileVersion))
+                    userAgentProduct = $"Gw2Sharp/{new Version(fileVersion).ToString(3)}";
             }
             catch { /* Ignore */ }
             this.UserAgent = $"{userAgent}{(!string.IsNullOrWhiteSpace(userAgent) ? " " : "")}" +

--- a/Gw2Sharp/Gw2Client.cs
+++ b/Gw2Sharp/Gw2Client.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using Gw2Sharp.Mumble;
 using Gw2Sharp.WebApi;
 
@@ -9,7 +10,7 @@ namespace Gw2Sharp
     /// </summary>
     public class Gw2Client : IGw2Client
     {
-        private readonly IGw2MumbleClient mumble;
+        private readonly IGw2MumbleClient? mumble;
         private readonly IGw2WebApiClient webApi;
 
         /// <summary>
@@ -27,12 +28,21 @@ namespace Gw2Sharp
             if (connection == null)
                 throw new ArgumentNullException(nameof(connection));
 
+#if NET5_0_OR_GREATER
+            if (OperatingSystem.IsWindows())
+                this.mumble = new Gw2MumbleClient();
+#else
             this.mumble = new Gw2MumbleClient();
+#endif
             this.webApi = new Gw2WebApiClient(connection, this);
         }
 
         /// <inheritdoc />
-        public virtual IGw2MumbleClient Mumble => this.mumble;
+#if NET5_0_OR_GREATER
+        [SupportedOSPlatform("windows")]
+#endif
+        public virtual IGw2MumbleClient Mumble =>
+            this.mumble ?? throw new PlatformNotSupportedException("Mumble Link is only available on Windows platforms");
 
         /// <inheritdoc />
         public virtual IGw2WebApiClient WebApi => this.webApi;
@@ -51,7 +61,7 @@ namespace Gw2Sharp
             {
                 if (disposing)
                 {
-                    this.mumble.Dispose();
+                    this.mumble?.Dispose();
                 }
 
                 this.isDisposed = true;

--- a/Gw2Sharp/Gw2Sharp.csproj
+++ b/Gw2Sharp/Gw2Sharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -28,12 +28,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.154" PrivateAssets="all" />
     <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.1.0]" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(VERSIONED_BUILD)'!=''">

--- a/Gw2Sharp/IGw2Client.cs
+++ b/Gw2Sharp/IGw2Client.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Versioning;
 using Gw2Sharp.Mumble;
 using Gw2Sharp.WebApi;
 
@@ -12,6 +13,10 @@ namespace Gw2Sharp
         /// <summary>
         /// Gets the Mumble Link client API.
         /// </summary>
+        /// <exception cref="PlatformNotSupportedException">Mumble Link is not available on non-Windows platforms.</exception>
+#if NET5_0_OR_GREATER
+        [SupportedOSPlatform("windows")]
+#endif
         IGw2MumbleClient Mumble { get; }
 
         /// <summary>

--- a/Gw2Sharp/Mumble/Gw2MumbleClient.cs
+++ b/Gw2Sharp/Mumble/Gw2MumbleClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Net.Sockets;
+using System.Runtime.Versioning;
 using System.Text.Json;
 using Gw2Sharp.Json;
 using Gw2Sharp.Models;
@@ -13,6 +14,9 @@ namespace Gw2Sharp.Mumble
     /// <summary>
     /// A client for the Guild Wars 2 Mumble Link API service.
     /// </summary>
+#if NET5_0_OR_GREATER
+    [SupportedOSPlatform("windows")]
+#endif
     public class Gw2MumbleClient : IGw2MumbleClient
     {
         /// <summary>

--- a/Gw2Sharp/WebApi/Http/WebApiRequest.cs
+++ b/Gw2Sharp/WebApi/Http/WebApiRequest.cs
@@ -70,7 +70,7 @@ namespace Gw2Sharp.WebApi.Http
                 ? url.Query[1..]
                     .Split(new[] { '&' }, StringSplitOptions.RemoveEmptyEntries)
                     .Select(x => x.Split('='))
-                    .ToDictionary(x => x[0], x => x.Skip(1).FirstOrDefault())
+                    .ToDictionary(x => x[0], x => x.Skip(1).FirstOrDefault() ?? string.Empty)
                 : new Dictionary<string, string>();
             requestHeaders = requestHeaders?.ShallowCopy() ?? new Dictionary<string, string>();
 

--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -125,8 +125,13 @@ var mumbleClient = client.Mumble;
 
 > [!WARNING]
 > The Mumble Link service client requires Guild Wars 2 to be running on a Windows operating system.
-> However, this validation is totally up to you.
-> The property `IsAvailable` will return `true` if the Guild Wars 2 Mumble Link API is available.
+>
+> Starting with .NET 5, using this property without checking if you're targeting a Windows platform, [will raise a warning](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1416).
+> Accessing the property will throw a `PlatformNotSupportedException`.
+> 
+> In .NET Framework and .NET Core however, `PlatformNotSupportedException` is thrown as soon as you're calling `Update()` after accessing the property.
+>
+> The property `IsAvailable` will return `true` if the Guild Wars 2 client is running and the Mumble Link API is available.
 
 > [!NOTE]
 > You are responsible for updating the Mumble Link values by calling the method `Update()`.


### PR DESCRIPTION
This adds a separate .NET 5 target in order to make use of the new attributes that can check for platform support. We'll use this for the Mumble Link API, which is only available on Windows. Using this API on any other platform will raise a compiler warning.

We now also explicitly throw the `PlatformNotSupportedException` on non-Windows versions ourselves, instead of letting it being handled by the underlying .NET system.