### PR TITLE
Add new legendary armory location enum values

### DIFF
--- a/Gw2Sharp.Tests/Json/Converters/ApiEnumConverterTests.cs
+++ b/Gw2Sharp.Tests/Json/Converters/ApiEnumConverterTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Gw2Sharp.Json.Converters;
 using Gw2Sharp.WebApi.V2.Models;
 using Xunit;
@@ -26,9 +27,12 @@ namespace Gw2Sharp.Tests.Json.Converters
                 Converters = { new ApiEnumConverter() }
             });
 
-            actual.IsUnknown.Should().BeFalse();
-            actual.Value.Should().Be(expectedValue);
-            actual.RawValue.Should().Be(expectedRaw);
+            using (new AssertionScope())
+            {
+                actual.IsUnknown.Should().BeFalse();
+                actual.Value.Should().Be(expectedValue);
+                actual.RawValue.Should().Be(expectedRaw);
+            }
         }
 
         [Theory]
@@ -41,9 +45,12 @@ namespace Gw2Sharp.Tests.Json.Converters
                 Converters = { new ApiEnumConverter() }
             });
 
-            actual.IsUnknown.Should().BeTrue();
-            actual.Value.Should().Be(expectedValue);
-            actual.RawValue.Should().Be(expectedRaw);
+            using (new AssertionScope())
+            {
+                actual.IsUnknown.Should().BeTrue();
+                actual.Value.Should().Be(expectedValue);
+                actual.RawValue.Should().Be(expectedRaw);
+            }
         }
 
         [Theory]

--- a/Gw2Sharp.Tests/Json/Converters/ApiFlagsConverterTests.cs
+++ b/Gw2Sharp.Tests/Json/Converters/ApiFlagsConverterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Text.Json;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Gw2Sharp.Json.Converters;
 using Gw2Sharp.WebApi.V2.Models;
 using Xunit;
@@ -22,7 +23,6 @@ namespace Gw2Sharp.Tests.Json.Converters
             new object[]
             {
                 "[\"Flag1\"]",
-                TestFlags.Flag1,
                 new[]
                 {
                     new ApiEnum<TestFlags>(TestFlags.Flag1, "Flag1")
@@ -31,7 +31,6 @@ namespace Gw2Sharp.Tests.Json.Converters
             new object[]
             {
                 "[\"Flag1\",\"Flag2\"]",
-                TestFlags.Flag1 | TestFlags.Flag2,
                 new[]
                 {
                     new ApiEnum<TestFlags>(TestFlags.Flag1, "Flag1"),
@@ -41,7 +40,6 @@ namespace Gw2Sharp.Tests.Json.Converters
             new object[]
             {
                 "[1,2]",
-                TestFlags.Flag1 | TestFlags.Flag2,
                 new[]
                 {
                     new ApiEnum<TestFlags>(TestFlags.Flag1, "1"),
@@ -51,7 +49,6 @@ namespace Gw2Sharp.Tests.Json.Converters
             new object[]
             {
                 "[\"Flag1\",2]",
-                TestFlags.Flag1 | TestFlags.Flag2,
                 new[]
                 {
                     new ApiEnum<TestFlags>(TestFlags.Flag1, "Flag1"),
@@ -62,16 +59,19 @@ namespace Gw2Sharp.Tests.Json.Converters
 
         [Theory]
         [MemberData(nameof(DeserializeCorrectlyWithoutUnknownsCases))]
-        public void DeserializeCorrectlyWithoutUnknowns(string json, TestFlags expectedValue, ApiEnum<TestFlags>[] expectedEnums)
+        public void DeserializeCorrectlyWithoutUnknowns(string json, ApiEnum<TestFlags>[] expectedEnums)
         {
             var actual = JsonSerializer.Deserialize<ApiFlags<TestFlags>>(json, new JsonSerializerOptions
             {
                 Converters = { new ApiFlagsConverter() }
             });
 
-            actual.HasUnknowns.Should().BeFalse();
-            actual.UnknownList.Should().BeEmpty();
-            actual.List.Should().BeEquivalentTo(expectedEnums);
+            using (new AssertionScope())
+            {
+                actual.HasUnknowns.Should().BeFalse();
+                actual.UnknownList.Should().BeEmpty();
+                actual.List.Should().BeEquivalentTo(expectedEnums);
+            }
         }
 
         public static readonly object[][] DeserializeCorrectlyWithUnknownsCases =
@@ -79,7 +79,6 @@ namespace Gw2Sharp.Tests.Json.Converters
             new object[]
             {
                 "[\"Flag1\",\"Unknown\"]",
-                TestFlags.Flag1,
                 new[]
                 {
                     new ApiEnum<TestFlags>(TestFlags.Flag1, "Flag1")
@@ -92,7 +91,6 @@ namespace Gw2Sharp.Tests.Json.Converters
             new object[]
             {
                 "[\"\",\"Flag2\"]",
-                TestFlags.Flag1 | TestFlags.Flag2,
                 new[]
                 {
                     new ApiEnum<TestFlags>(TestFlags.Flag2, "Flag2")
@@ -106,16 +104,19 @@ namespace Gw2Sharp.Tests.Json.Converters
 
         [Theory]
         [MemberData(nameof(DeserializeCorrectlyWithUnknownsCases))]
-        public void DeserializeCorrectlyWithUnknowns(string json, TestFlags expectedValue, ApiEnum<TestFlags>[] expectedEnums, ApiEnum<TestFlags>[] expectedUnknowns)
+        public void DeserializeCorrectlyWithUnknowns(string json, ApiEnum<TestFlags>[] expectedEnums, ApiEnum<TestFlags>[] expectedUnknowns)
         {
             var actual = JsonSerializer.Deserialize<ApiFlags<TestFlags>>(json, new JsonSerializerOptions
             {
                 Converters = { new ApiFlagsConverter() }
             });
 
-            actual.HasUnknowns.Should().BeTrue();
-            actual.UnknownList.Should().BeEquivalentTo(expectedUnknowns);
-            actual.List.Should().BeEquivalentTo(expectedEnums.Concat(expectedUnknowns));
+            using (new AssertionScope())
+            {
+                actual.HasUnknowns.Should().BeTrue();
+                actual.UnknownList.Should().BeEquivalentTo(expectedUnknowns);
+                actual.List.Should().BeEquivalentTo(expectedEnums.Concat(expectedUnknowns));
+            }
         }
 
         [Theory]
@@ -131,7 +132,6 @@ namespace Gw2Sharp.Tests.Json.Converters
             action.Should().Throw<JsonException>();
         }
 
-        [Flags]
         public enum TestFlags
         {
             Flag1 = 1,

--- a/Gw2Sharp.Tests/TestFiles/Characters/Characters.single.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/Characters.single.json
@@ -109,7 +109,8 @@
           "id": 6479,
           "slot": "HelmAquatic",
           "binding": "Character",
-          "bound_to": "Bob"
+          "bound_to": "Bob",
+          "location": "Equipped"
         },
         {
           "id": 77474,
@@ -128,7 +129,8 @@
               "ConditionDuration": 27
             }
           },
-          "binding": "Account"
+          "binding": "Account",
+          "location": "EquippedFromLegendaryArmory"
         },
         {
           "id": 80254,
@@ -154,7 +156,8 @@
             1155,
             6,
             null
-          ]
+          ],
+          "location": "Equipped"
         },
         {
           "id": 80557,
@@ -180,7 +183,8 @@
             1155,
             6,
             null
-          ]
+          ],
+          "location": "Equipped"
         },
         {
           "id": 78984,
@@ -201,24 +205,127 @@
               "ConditionDuration": 59
             }
           },
-          "binding": "Account"
+          "binding": "Account",
+          "location": "Equipped"
+        }
+      ],
+      "equipment_pvp": {
+        "amulet": 14,
+        "rune": 21172,
+        "sigils": [
+          21152,
+          21150,
+          21152,
+          null
+        ]
+      }
+    },
+    {
+      "tab": 2,
+      "is_active": false,
+      "equipment": [
+        {
+          "id": 6479,
+          "slot": "HelmAquatic",
+          "binding": "Character",
+          "bound_to": "Bob",
+          "location": "Armory"
         },
         {
-          "id": 49308,
-          "slot": "Sickle",
-          "binding": "Account"
+          "id": 77474,
+          "slot": "Backpack",
+          "infusions": [
+            78052,
+            78028
+          ],
+          "skin": 2352,
+          "stats": {
+            "id": 1130,
+            "attributes": {
+              "Power": 52,
+              "Precision": 27,
+              "ConditionDamage": 52,
+              "ConditionDuration": 27
+            }
+          },
+          "binding": "Account",
+          "location": "LegendaryArmory"
         },
         {
-          "id": 48931,
-          "slot": "Axe",
-          "skin": 8087,
-          "binding": "Account"
+          "id": 80254,
+          "slot": "Coat",
+          "upgrades": [
+            83502
+          ],
+          "infusions": [
+            70852
+          ],
+          "stats": {
+            "id": 1153,
+            "attributes": {
+              "Power": 121,
+              "Precision": 67,
+              "ConditionDamage": 121,
+              "ConditionDuration": 67
+            }
+          },
+          "binding": "Account",
+          "dyes": [
+            11,
+            1155,
+            6,
+            null
+          ],
+          "location": "Armory"
         },
         {
-          "id": 87422,
-          "slot": "Pick",
-          "skin": 8097,
-          "binding": "Account"
+          "id": 80557,
+          "slot": "Boots",
+          "upgrades": [
+            83502
+          ],
+          "infusions": [
+            70852
+          ],
+          "stats": {
+            "id": 1153,
+            "attributes": {
+              "Power": 40,
+              "Precision": 22,
+              "ConditionDamage": 40,
+              "ConditionDuration": 22
+            }
+          },
+          "binding": "Account",
+          "dyes": [
+            11,
+            1155,
+            6,
+            null
+          ],
+          "location": "Armory"
+        },
+        {
+          "id": 78984,
+          "slot": "WeaponA1",
+          "upgrades": [
+            24605
+          ],
+          "infusions": [
+            49432
+          ],
+          "skin": 6588,
+          "stats": {
+            "id": 1224,
+            "attributes": {
+              "Power": 108,
+              "Precision": 59,
+              "ConditionDamage": 108,
+              "ConditionDuration": 59
+            }
+          },
+          "binding": "Account",
+          "location": "Armory"
         }
       ],
       "equipment_pvp": {
@@ -244,7 +351,7 @@
     },
     {
       "id": 77474,
-      "location": "Equipped",
+      "location": "EquippedFromLegendaryArmory",
       "slot": "Backpack",
       "tabs": [ 1 ],
       "infusions": [

--- a/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipment.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipment.json
@@ -10,7 +10,7 @@
     },
     {
       "id": 77474,
-      "location": "Equipped",
+      "location": "EquippedFromLegendaryArmory",
       "slot": "Backpack",
       "tabs": [ 1 ],
       "infusions": [

--- a/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.bulk.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.bulk.json
@@ -13,7 +13,7 @@
       },
       {
         "id": 77474,
-        "location": "Equipped",
+        "location": "EquippedFromLegendaryArmory",
         "slot": "Backpack",
         "tabs": [ 1 ],
         "infusions": [
@@ -204,7 +204,7 @@
       },
       {
         "id": 42024,
-        "location": "Armory",
+        "location": "LegendaryArmory",
         "slot": "WeaponAquaticA",
         "tabs": [ 2 ],
         "binding": "Character",

--- a/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.single.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.single.json
@@ -12,7 +12,7 @@
     },
     {
       "id": 77474,
-      "location": "Equipped",
+      "location": "EquippedFromLegendaryArmory",
       "slot": "Backpack",
       "tabs": [ 1 ],
       "infusions": [

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersClient.cs
@@ -8,7 +8,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// </summary>
     [EndpointPath("characters")]
     [EndpointBulkIdName("name")]
-    [EndpointSchemaVersion("2021-04-06T21:00:00.000Z")]
+    [EndpointSchemaVersion("2021-07-15T13:00:00.000Z")]
     public class CharactersClient : BaseEndpointBulkAllClient<Character, string>, ICharactersClient
     {
         /// <summary>

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdClient.cs
@@ -8,7 +8,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// </summary>
     [EndpointPath("characters/:id")]
     [EndpointPathSegment("id", 0)]
-    [EndpointSchemaVersion("2019-12-19T00:00:00.000Z")]
+    [EndpointSchemaVersion("2021-07-15T13:00:00.000Z")]
     public class CharactersIdClient : BaseEndpointBlobClient<Character>, ICharactersIdClient
     {
         private readonly string characterName;

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsActiveClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsActiveClient.cs
@@ -7,7 +7,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// A client of the Guild Wars 2 API v2 characters id equipment tabs active client.
     /// </summary>
     [EndpointPath("characters/:id/equipmenttabs/active")]
-    [EndpointSchemaVersion("2021-04-06T21:00:00.000Z")]
+    [EndpointSchemaVersion("2021-07-15T13:00:00.000Z")]
     public class CharactersIdEquipmentTabsActiveClient : BaseCharactersSubBlobClient<CharacterEquipmentTabSlot>, ICharactersIdEquipmentTabsActiveClient
     {
         /// <summary>

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsClient.cs
@@ -8,7 +8,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// </summary>
     [EndpointPath("characters/:id/equipmenttabs")]
     [EndpointBulkIdName("tab", "tabs", "tab")]
-    [EndpointSchemaVersion("2021-04-06T21:00:00.000Z")]
+    [EndpointSchemaVersion("2021-07-15T13:00:00.000Z")]
     public class CharactersIdEquipmentTabsClient : BaseCharactersSubBulkClient<CharacterEquipmentTabSlot, int>, ICharactersIdEquipmentTabsClient
     {
         private readonly ICharactersIdEquipmentTabsActiveClient active;

--- a/Gw2Sharp/WebApi/V2/Models/Characters/ItemEquipmentLocationType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/ItemEquipmentLocationType.cs
@@ -6,18 +6,28 @@ namespace Gw2Sharp
     public enum ItemEquipmentLocationType
     {
         /// <summary>
-        /// Unknown location.
+        /// Unknown location type.
         /// </summary>
         Unknown,
 
         /// <summary>
-        /// The equipped location.
+        /// The equipped location type.
         /// </summary>
         Equipped,
 
         /// <summary>
-        /// The armory location.
+        /// The armory location type.
         /// </summary>
-        Armory
+        Armory,
+
+        /// <summary>
+        /// The equipped from legendary armory location type.
+        /// </summary>
+        EquippedFromLegendaryArmory,
+
+        /// <summary>
+        /// The legendary armory location type.
+        /// </summary>
+        LegendaryArmory
     }
 }


### PR DESCRIPTION
This updates the main character endpoint, and the equipment tab subendpoint to schema `2021-07-15T13:00:00.000Z` that includes the `EquippedFromLegendaryArmory` and `LegendaryArmory` enum values for the equipment location.

Coincidentally, this also fixes the oversight where the individual character by id endpoint didn't have the latest schema version applied, resulting in `Client.Characters["character-name"].GetAsync()` using the old schema `2019-12-19T00:00:00.000Z` that didn't have the changes of `equipment_pvp` applied from schema `2021-04-06T21:00:00.000Z`.