### PR TITLE
Fix namespaces of various enums

### DIFF
--- a/Gw2Sharp/WebApi/Caching/CacheItemStatus.cs
+++ b/Gw2Sharp/WebApi/Caching/CacheItemStatus.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.Caching
 {
     /// <summary>
     /// The cache item status.

--- a/Gw2Sharp/WebApi/Caching/CacheItemType.cs
+++ b/Gw2Sharp/WebApi/Caching/CacheItemType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.Caching
 {
     /// <summary>
     /// The cache item type.

--- a/Gw2Sharp/WebApi/V2/Models/Characters/ItemEquipmentLocationType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/ItemEquipmentLocationType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The item equipment location type.

--- a/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionFlag.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionFlag.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The profession flag.

--- a/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionTrainingCategory.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionTrainingCategory.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The profession training category.

--- a/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionTrainingTrackStepType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionTrainingTrackStepType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The profession training track step type.

--- a/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionWeaponFlag.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionWeaponFlag.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The profession weapon flags.

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonDivisionFlag.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonDivisionFlag.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The PvP season division flag.

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardScoringOrder.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardScoringOrder.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The PvP season leaderboard scoring order.

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardScoringType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardScoringType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The PvP season leaderboard scoring type.

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardSettingsTierType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardSettingsTierType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The PvP season leaderboard settings tier type.

--- a/Gw2Sharp/WebApi/V2/Models/Raids/RaidWingEventType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Raids/RaidWingEventType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The raid wing event type.

--- a/Gw2Sharp/WebApi/V2/Models/SkillType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/SkillType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// The skill type.

--- a/Gw2Sharp/WebApi/V2/Models/Skills/ComboFieldType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/ComboFieldType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// A combo field type.

--- a/Gw2Sharp/WebApi/V2/Models/Skills/ComboFinisherType.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/ComboFinisherType.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// A combo finisher type.

--- a/Gw2Sharp/WebApi/V2/Models/Skills/SkillFlag.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/SkillFlag.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// A skill flag.

--- a/Gw2Sharp/WebApi/V2/Models/Skins/SkinFlag.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skins/SkinFlag.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// A skin flag.

--- a/Gw2Sharp/WebApi/V2/Models/Stories/StoryFlag.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Stories/StoryFlag.cs
@@ -1,4 +1,4 @@
-namespace Gw2Sharp
+namespace Gw2Sharp.WebApi.V2.Models
 {
     /// <summary>
     /// A story flag.


### PR DESCRIPTION
Some enums somehow got the wrong namespace. They were placed in the root Gw2Sharp namespace, instead of `Gw2Sharp.WebApi.V2.Models` or `Gw2Sharp.WebApi.V2.Caching`.