### PR TITLE
Make deprecated equipment PvP property uncompilable

### DIFF
--- a/Gw2Sharp.Tests/WebApi/V2/Clients/Characters/CharactersClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/Characters/CharactersClientTests.cs
@@ -1,6 +1,4 @@
-using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Gw2Sharp.WebApi.V2.Clients;
 using Xunit;
 
@@ -32,17 +30,5 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
         [Theory]
         [InlineData("TestFiles.Characters.Characters.ids.json")]
         public Task IdsTestAsync(string file) => this.AssertIdsDataAsync(this.Client, file);
-
-#pragma warning disable CS0618
-        [Theory]
-        [InlineData("TestFiles.Characters.Characters.EquipmentTabs.json")]
-        [InlineData("TestFiles.Characters.Characters.EquipmentTabs.Null.json")]
-        public async Task EquipmentPvpRollForwardTest(string file)
-        {
-            // This roll-forward capability will be removed from Gw2Sharp starting with version 2.0
-            var actual = await this.AssertGetDataAsync(this.Client, file, "name");
-            actual.EquipmentPvp.Should().BeEquivalentTo(actual.EquipmentTabs?.Single(x => x.Tab == actual.ActiveEquipmentTab).EquipmentPvp);
-        }
-#pragma warning restore CS0618
     }
 }

--- a/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Gw2Sharp.WebApi.V2.Clients;
 
 namespace Gw2Sharp.WebApi.V2.Models
@@ -159,15 +158,11 @@ namespace Gw2Sharp.WebApi.V2.Models
         public IReadOnlyList<int>? Recipes { get; set; }
 
         /// <summary>
-        /// The character PvP equipment.
-        /// Additionally requires scopes: builds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// Deprecated. Use <see cref="CharacterEquipmentTabSlot.EquipmentPvp"/> in <see cref="EquipmentTabs"/> instead.
         /// </summary>
-        [Obsolete("Deprecated since schema version 2021-04-06T21:00:00.000Z. Use EquipmentTabs[i].EquipmentPvp instead. This will be removed from Gw2Sharp starting from version 2.0.")]
+        [Obsolete("This has been deprecated since version 2.0. Use EquipmentTabs[i].EquipmentPvp instead.", true)]
         public CharacterEquipmentPvp? EquipmentPvp =>
-            // Instead of using the old schema version to pull this information while also supporting the latest schema,
-            // we emulate the migration roll-forward ability ourselves by grabbing the current active tab information.
-            this.EquipmentTabs?.FirstOrDefault(x => x.Tab == this.ActiveEquipmentTab)?.EquipmentPvp;
+            throw new NotSupportedException("This has been deprecated since version 2.0. Use EquipmentTabs[i].EquipmentPvp instead.");
 
         /// <summary>
         /// The list of character trainings.


### PR DESCRIPTION
This will make the deprecated equipment PvP part of the characters endpoint uncompilable with a hint of what the replacement is. If the property is somehow still accessed (e.g. via reflection), it will throw a NotSupportedException because the code to support the backwards compatibility has been removed entirely.