### PR TITLE
Refactor web API exceptions

### DIFF
--- a/Gw2Sharp.Tests/WebApi/Exceptions/RequestExceptionTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Exceptions/RequestExceptionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Gw2Sharp.WebApi.Exceptions;
 using Gw2Sharp.WebApi.Http;
+using Gw2Sharp.WebApi.V2.Models;
 using NSubstitute;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace Gw2Sharp.Tests.WebApi.Exceptions
         public void ConstructorTest()
         {
             var request = Substitute.For<IWebApiRequest>();
-            var response = Substitute.For<IWebApiResponse>();
+            var response = Substitute.For<IWebApiResponse<ErrorObject>>();
             var innerException = new NotImplementedException();
             string message = "test exception";
 

--- a/Gw2Sharp.Tests/WebApi/Exceptions/UnexpectedStatusExceptionTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Exceptions/UnexpectedStatusExceptionTests.cs
@@ -1,5 +1,6 @@
 using Gw2Sharp.WebApi.Exceptions;
 using Gw2Sharp.WebApi.Http;
+using Gw2Sharp.WebApi.V2.Models;
 using NSubstitute;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace Gw2Sharp.Tests.WebApi.Exceptions
         public void ConstructorTest()
         {
             var request = Substitute.For<IWebApiRequest>();
-            var response = Substitute.For<IWebApiResponse>();
+            var response = Substitute.For<IWebApiResponse<ErrorObject>>();
             string message = "test exception";
 
             var exception = new UnexpectedStatusException(request, response);

--- a/Gw2Sharp/WebApi/Exceptions/AuthorizationRequiredException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/AuthorizationRequiredException.cs
@@ -7,8 +7,8 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails to authorize (code 403).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
-    public class AuthorizationRequiredException : UnexpectedStatusException<ErrorObject>
+    /// <seealso cref="UnexpectedStatusException" />
+    public class AuthorizationRequiredException : UnexpectedStatusException
     {
         /// <summary>
         /// Creates a new <see cref="AuthorizationRequiredException"/>.
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="error">The error.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/>, <paramref name="response"/> or <paramref name="error"/> is <c>null</c>.</exception>
         public AuthorizationRequiredException(IWebApiRequest request, IWebApiResponse<ErrorObject> response, AuthorizationError error) :
-            base(request, response, response?.Content.Message ?? string.Empty)
+            base(request, response)
         {
             this.AuthorizationError = error;
         }

--- a/Gw2Sharp/WebApi/Exceptions/BadRequestException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/BadRequestException.cs
@@ -7,8 +7,8 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a bad request was done (code 400).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
-    public class BadRequestException : UnexpectedStatusException<ErrorObject>
+    /// <seealso cref="UnexpectedStatusException" />
+    public class BadRequestException : UnexpectedStatusException
     {
         /// <summary>
         /// Creates a new <see cref="BadRequestException"/>.
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="error">The error.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public BadRequestException(IWebApiRequest request, IWebApiResponse<ErrorObject> response, BadRequestError error) :
-            base(request, response, response?.Content.Message ?? string.Empty)
+            base(request, response)
         {
             this.BadRequestError = error;
         }

--- a/Gw2Sharp/WebApi/Exceptions/InvalidAccessTokenException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/InvalidAccessTokenException.cs
@@ -7,7 +7,7 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails to authorize due to an invalid API key (code 403).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
+    /// <seealso cref="AuthorizationRequiredException" />
     public class InvalidAccessTokenException : AuthorizationRequiredException
     {
         /// <summary>
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public InvalidAccessTokenException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, AuthorizationError.InvalidKey) { }
+            base(request, response, AuthorizationError.InvalidKey)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/MembershipRequiredException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/MembershipRequiredException.cs
@@ -7,7 +7,7 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails to authorize due to the owner of the API key not being a member of the guild (code 403).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
+    /// <seealso cref="AuthorizationRequiredException" />
     public class MembershipRequiredException : AuthorizationRequiredException
     {
         /// <summary>
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public MembershipRequiredException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, AuthorizationError.MembershipRequired) { }
+            base(request, response, AuthorizationError.MembershipRequired)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/MissingScopesException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/MissingScopesException.cs
@@ -7,7 +7,7 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails to authorize due to missing permissions (code 403).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
+    /// <seealso cref="AuthorizationRequiredException" />
     public class MissingScopesException : AuthorizationRequiredException
     {
         /// <summary>
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public MissingScopesException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, AuthorizationError.MissingScopes) { }
+            base(request, response, AuthorizationError.MissingScopes)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/NotFoundException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/NotFoundException.cs
@@ -7,8 +7,8 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a response cannot be found (code 404).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
-    public class NotFoundException : UnexpectedStatusException<ErrorObject>
+    /// <seealso cref="UnexpectedStatusException" />
+    public class NotFoundException : UnexpectedStatusException
     {
         /// <summary>
         /// Creates a new <see cref="NotFoundException"/>.
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public NotFoundException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, response?.Content.Message ?? string.Empty) { }
+            base(request, response)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/RequestException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/RequestException.cs
@@ -1,12 +1,13 @@
 using System;
 using Gw2Sharp.WebApi.Http;
+using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.Exceptions
 {
     /// <summary>
     /// A generic request exception used for the web API.
     /// </summary>
-    public class RequestException : RequestException<string>
+    public class RequestException : Exception
     {
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
@@ -15,7 +16,8 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="message">The message.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
         public RequestException(IWebApiRequest request, string message) :
-            base(request, message) { }
+            this(request, null, message, null)
+        { }
 
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
@@ -24,8 +26,9 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
-        public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message) :
-            base(request, response, message) { }
+        public RequestException(IWebApiRequest request, IWebApiResponse<ErrorObject>? response, string message) :
+            this(request, response, message, null)
+        { }
 
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
@@ -35,7 +38,8 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="innerException">The inner exception.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
         public RequestException(IWebApiRequest request, string message, Exception? innerException) :
-            base(request, message, innerException) { }
+            this(request, null, message, innerException)
+        { }
 
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
@@ -44,55 +48,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
-        public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message, Exception innerException) :
-            base(request, response, message, innerException) { }
-    }
-
-
-    /// <summary>
-    /// A generic request exception used for the web API.
-    /// </summary>
-    /// <typeparam name="TResponse">The response object.</typeparam>
-    public class RequestException<TResponse> : Exception
-    {
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
-        public RequestException(IWebApiRequest request, string message) :
-            this(request, null, message, null) { }
-
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="response">The response.</param>
-        /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
-        public RequestException(IWebApiRequest request, IWebApiResponse<TResponse>? response, string message) :
-            this(request, response, message, null) { }
-
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="message">The message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
-        public RequestException(IWebApiRequest request, string message, Exception? innerException) :
-            this(request, null, message, innerException) { }
-
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="response">The response.</param>
-        /// <param name="message">The message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        public RequestException(IWebApiRequest request, IWebApiResponse<TResponse>? response, string message, Exception? innerException) :
+        public RequestException(IWebApiRequest request, IWebApiResponse<ErrorObject>? response, string message, Exception? innerException) :
             base(message, innerException)
         {
             this.Request = request ?? throw new ArgumentNullException(nameof(request));
@@ -107,6 +63,6 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <summary>
         /// Gets the response.
         /// </summary>
-        public IWebApiResponse<TResponse>? Response { get; }
+        public IWebApiResponse<ErrorObject>? Response { get; }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/RestrictedToGuildLeadersException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/RestrictedToGuildLeadersException.cs
@@ -7,7 +7,7 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails to authorize due to the owner not being a guild leader (code 403).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
+    /// <seealso cref="AuthorizationRequiredException" />
     public class RestrictedToGuildLeadersException : AuthorizationRequiredException
     {
         /// <summary>
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public RestrictedToGuildLeadersException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, AuthorizationError.AccessRestrictedToGuildLeaders) { }
+            base(request, response, AuthorizationError.AccessRestrictedToGuildLeaders)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/ServerErrorException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/ServerErrorException.cs
@@ -7,8 +7,8 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails due to an internal server error (code 500).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
-    public class ServerErrorException : UnexpectedStatusException<ErrorObject>
+    /// <seealso cref="UnexpectedStatusException" />
+    public class ServerErrorException : UnexpectedStatusException
     {
         /// <summary>
         /// Creates a new <see cref="ServerErrorException"/>.
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public ServerErrorException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, response?.Content.Message ?? string.Empty) { }
+            base(request, response)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/ServiceUnavailableException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/ServiceUnavailableException.cs
@@ -7,8 +7,8 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails due to the service being unavailable (code 500).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
-    public class ServiceUnavailableException : UnexpectedStatusException<ErrorObject>
+    /// <seealso cref="UnexpectedStatusException" />
+    public class ServiceUnavailableException : UnexpectedStatusException
     {
         /// <summary>
         /// Creates a new <see cref="ServiceUnavailableException"/>.
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public ServiceUnavailableException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, response?.Content.Message ?? string.Empty) { }
+            base(request, response)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/TooManyRequestsException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/TooManyRequestsException.cs
@@ -7,8 +7,8 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A web API specific exception that's used when a request fails due to issuing too many requests in a short period of time (code 429).
     /// </summary>
-    /// <seealso cref="UnexpectedStatusException{Error}" />
-    public class TooManyRequestsException : UnexpectedStatusException<ErrorObject>
+    /// <seealso cref="UnexpectedStatusException" />
+    public class TooManyRequestsException : UnexpectedStatusException
     {
         /// <summary>
         /// Creates a new <see cref="TooManyRequestsException"/>.
@@ -17,6 +17,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
         public TooManyRequestsException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
-            base(request, response, response?.Content.Message ?? string.Empty) { }
+            base(request, response)
+        { }
     }
 }

--- a/Gw2Sharp/WebApi/Exceptions/UnexpectedStatusException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/UnexpectedStatusException.cs
@@ -1,5 +1,6 @@
 using System;
 using Gw2Sharp.WebApi.Http;
+using Gw2Sharp.WebApi.V2.Models;
 
 namespace Gw2Sharp.WebApi.Exceptions
 {
@@ -14,8 +15,9 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
-        public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<string> response) :
-            this(request, response, $"Unexpected HTTP status code: {(int?)response?.StatusCode ?? 0}") { }
+        public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
+            this(request, response, FormatMessage(response))
+        { }
 
         /// <summary>
         /// Creates a new <see cref="UnexpectedStatusException" />.
@@ -24,31 +26,20 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
         /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
-        public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<string>? response, string message) :
-            base(request, response, message) { }
-    }
+        public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<ErrorObject>? response, string message) :
+            base(request, response, message)
+        { }
 
-    /// <summary>
-    /// An exception that's used when an HTTP request returned an unexpected status code, e.g. a non-successful one.
-    /// </summary>
-    public class UnexpectedStatusException<T> : RequestException<T>
-    {
-        /// <summary>
-        /// Creates a new <see cref="UnexpectedStatusException{T}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="response">The response.</param>
-        public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<T> response) :
-            this(request, response, $"Unexpected HTTP status code: {(int?)response?.StatusCode ?? 0}") { }
 
-        /// <summary>
-        /// Creates a new <see cref="UnexpectedStatusException{T}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="response">The response.</param>
-        /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
-        public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<T>? response, string message) :
-            base(request, response, message) { }
+        private static string FormatMessage(IWebApiResponse<ErrorObject> response)
+        {
+            if (response is null)
+                return "Unexpected response (no additional information available)";
+
+            if (!string.IsNullOrEmpty(response.Content?.Message))
+                return response.Content.Message;
+
+            return $"Unexpected HTTP status code: {(int)response.StatusCode}";
+        }
     }
 }

--- a/Gw2Sharp/WebApi/Http/IWebApiResponse.cs
+++ b/Gw2Sharp/WebApi/Http/IWebApiResponse.cs
@@ -11,12 +11,6 @@ namespace Gw2Sharp.WebApi.Http
     /// </summary>
     public interface IWebApiResponse : IWebApiResponse<string>
     {
-        /// <summary>
-        /// Creates a copy of the request.
-        /// This deep copies <see cref="IWebApiResponse{T}.ResponseHeaders" />.
-        /// </summary>
-        /// <returns>The cloned response.</returns>
-        new IWebApiResponse Copy();
     }
 
     /// <summary>
@@ -44,13 +38,6 @@ namespace Gw2Sharp.WebApi.Http
         /// The response headers.
         /// </summary>
         IDictionary<string, string> ResponseHeaders { get; }
-
-        /// <summary>
-        /// Creates a copy of the request.
-        /// This deep copies <see cref="IWebApiResponse{T}.ResponseHeaders" />, but copies <see cref="Content" /> by reference.
-        /// </summary>
-        /// <returns>The cloned response.</returns>
-        IWebApiResponse<T> Copy();
     }
 
 

--- a/Gw2Sharp/WebApi/Http/WebApiResponse.cs
+++ b/Gw2Sharp/WebApi/Http/WebApiResponse.cs
@@ -39,10 +39,6 @@ namespace Gw2Sharp.WebApi.Http
         /// <exception cref="ArgumentNullException"><paramref name="content"/> is <c>null</c>.</exception>
         public WebApiResponse(string content, HttpStatusCode? statusCode, CacheState cacheState, IEnumerable<KeyValuePair<string, string>>? responseHeaders)
             : base(content, statusCode, cacheState, responseHeaders) { }
-
-        /// <inheritdoc />
-        public new IWebApiResponse Copy() =>
-            new WebApiResponse(this.Content, this.StatusCode, this.CacheState, this.ResponseHeaders);
     }
 
     /// <summary>
@@ -100,9 +96,5 @@ namespace Gw2Sharp.WebApi.Http
 
         /// <inheritdoc />
         public IDictionary<string, string> ResponseHeaders { get; } = new Dictionary<string, string>();
-
-        /// <inheritdoc />
-        public IWebApiResponse<T> Copy() =>
-            new WebApiResponse<T>(this.Content, this.StatusCode, this.CacheState, this.ResponseHeaders);
     }
 }

--- a/Gw2Sharp/WebApi/Middleware/ExceptionMiddleware.cs
+++ b/Gw2Sharp/WebApi/Middleware/ExceptionMiddleware.cs
@@ -70,7 +70,7 @@ namespace Gw2Sharp.WebApi.Middleware
 #endif
                     HttpStatusCode.InternalServerError => new ServerErrorException(context.Request, errorResponse),
                     HttpStatusCode.ServiceUnavailable => new ServiceUnavailableException(context.Request, errorResponse),
-                    _ => new UnexpectedStatusException(context.Request, httpResponse, httpResponse.Content)
+                    _ => new UnexpectedStatusException(context.Request, errorResponse)
                 };
             }
         }


### PR DESCRIPTION
The generic typed exceptions have been entirely removed, making it easier to catch exceptions thrown from Gw2Sharp.

This is a breaking change, and is going to be effective starting from version 2.0.

Closes #96 