### PR TITLE
Fix langword usage in docs

### DIFF
--- a/Gw2Sharp/ChatLinks/Gw2ChatLink.cs
+++ b/Gw2Sharp/ChatLinks/Gw2ChatLink.cs
@@ -147,7 +147,7 @@ namespace Gw2Sharp.ChatLinks
         /// </summary>
         /// <param name="chatLinkString">The chat link string.</param>
         /// <param name="chatLink">The chat link if <paramref name="chatLinkString"/> is a valid chat link.</param>
-        /// <returns><c>true</c> if <paramref name="chatLinkString"/> is a valid chat link; <c>false</c> otherwise.</returns>
+        /// <returns><see langword="true"/> if <paramref name="chatLinkString"/> is a valid chat link; <see langword="false"/> otherwise.</returns>
         public static bool TryParse(string chatLinkString, [NotNullWhen(true)] out IGw2ChatLink? chatLink)
         {
             try

--- a/Gw2Sharp/ChatLinks/ItemChatLink.cs
+++ b/Gw2Sharp/ChatLinks/ItemChatLink.cs
@@ -28,21 +28,21 @@ namespace Gw2Sharp.ChatLinks
 
         /// <summary>
         /// The skin id.
-        /// If the chat link doesn't contain a skin, this value is <c>null</c>.
+        /// If the chat link doesn't contain a skin, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skins"/>.
         /// </summary>
         public int? SkinId { get; set; }
 
         /// <summary>
         /// The first upgrade id.
-        /// If the chat link doesn't contain a first upgrade, this value is <c>null</c>.
+        /// If the chat link doesn't contain a first upgrade, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public int? Upgrade1Id { get; set; }
 
         /// <summary>
         /// The second upgrade id.
-        /// If the chat link doesn't contain a second upgrade, this value is <c>null</c>.
+        /// If the chat link doesn't contain a second upgrade, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public int? Upgrade2Id { get; set; }

--- a/Gw2Sharp/Extensions/DictionaryExtensions.cs
+++ b/Gw2Sharp/Extensions/DictionaryExtensions.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.Extensions
         /// <param name="source">The source enumerable.</param>
         /// <returns>A shallow copy in the form of a dictionary.</returns>
         /// <exception cref="ArgumentException"><paramref name="source"/> contains duplicate keys.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         public static IDictionary<TKey, TValue> ShallowCopy<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
             where TKey : notnull
         {
@@ -36,7 +36,7 @@ namespace Gw2Sharp.Extensions
         /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
         /// <param name="dictionary">The dictionary.</param>
         /// <param name="values">The values to add.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <see langword="null"/>.</exception>
         public static void AddRange<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, IEnumerable<KeyValuePair<TKey, TValue>> values)
             where TKey : notnull
         {
@@ -57,7 +57,7 @@ namespace Gw2Sharp.Extensions
         /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
         /// <param name="dictionary">The dictionary.</param>
         /// <returns>The read-only dictionary.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <see langword="null"/>.</exception>
         public static IReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
             where TKey : notnull
         {

--- a/Gw2Sharp/Extensions/EnumerableExtensions.cs
+++ b/Gw2Sharp/Extensions/EnumerableExtensions.cs
@@ -10,12 +10,12 @@ namespace Gw2Sharp.Extensions
     internal static class EnumerableExtensions
     {
         /// <summary>
-        /// Filters a sequence of values where <c>null</c> values are not present.
+        /// Filters a sequence of values where <see langword="null"/> values are not present.
         /// </summary>
         /// <typeparam name="T">The type.</typeparam>
         /// <param name="source">The source enumerable.</param>
-        /// <returns>An enumerable without <c>null</c> values.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
+        /// <returns>An enumerable without <see langword="null"/> values.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class
         {
             if (source is null)
@@ -27,12 +27,12 @@ namespace Gw2Sharp.Extensions
         }
 
         /// <summary>
-        /// Filters a sequence of values where <c>null</c> values are not present.
+        /// Filters a sequence of values where <see langword="null"/> values are not present.
         /// </summary>
         /// <typeparam name="T">The type.</typeparam>
         /// <param name="source">The source enumerable.</param>
-        /// <returns>An enumerable without <c>null</c> values.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
+        /// <returns>An enumerable without <see langword="null"/> values.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : struct
         {
             if (source is null)

--- a/Gw2Sharp/Extensions/StringExtensions.cs
+++ b/Gw2Sharp/Extensions/StringExtensions.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.Extensions
         /// </summary>
         /// <param name="str">The string.</param>
         /// <returns>The SHA-1 hash.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="str"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is <see langword="null"/>.</exception>
         public static string GetSha1Hash(this string str)
         {
             if (str == null)
@@ -30,12 +30,12 @@ namespace Gw2Sharp.Extensions
         }
 
         /// <summary>
-        /// Use a default string if the given string is <c>null</c> or empty.
+        /// Use a default string if the given string is <see langword="null"/> or empty.
         /// Shorthand for <code>string.IsNullOrEmpty(str) ? "default" : str</code>
         /// </summary>
         /// <param name="str">The string to check.</param>
-        /// <param name="default">The default string if the given string is <c>null</c> or empty.</param>
-        /// <returns>The original string if it's not <c>null</c> or empty; <paramref name="default"/> otherwise.</returns>
+        /// <param name="default">The default string if the given string is <see langword="null"/> or empty.</param>
+        /// <returns>The original string if it's not <see langword="null"/> or empty; <paramref name="default"/> otherwise.</returns>
         public static string OrIfNullOrEmpty(this string? str, string @default) =>
             !string.IsNullOrEmpty(str) ? str : @default;
     }

--- a/Gw2Sharp/Gw2Client.cs
+++ b/Gw2Sharp/Gw2Client.cs
@@ -22,7 +22,7 @@ namespace Gw2Sharp
         /// Creates a new <see cref="Gw2Client"/>.
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         public Gw2Client(IConnection connection)
         {
             if (connection == null)

--- a/Gw2Sharp/IConnection.cs
+++ b/Gw2Sharp/IConnection.cs
@@ -35,13 +35,13 @@ namespace Gw2Sharp
         /// <summary>
         /// Gets the HTTP client that's used for the API requests.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><c>value</c> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><c>value</c> is <see langword="null"/>.</exception>
         IHttpClient HttpClient { get; }
 
         /// <summary>
         /// Gets the cache controller that's used for API requests.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><c>value</c> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><c>value</c> is <see langword="null"/>.</exception>
         ICacheMethod CacheMethod { get; }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Gw2Sharp
         /// <summary>
         /// Gets the cache controller that's used for render file API requests.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><c>value</c> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><c>value</c> is <see langword="null"/>.</exception>
         ICacheMethod RenderCacheMethod { get; }
 
         /// <summary>

--- a/Gw2Sharp/WebApi/Caching/ArchiveCacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/ArchiveCacheMethod.cs
@@ -30,7 +30,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// Creates a new file archive caching method with the default cache duration (one day).
         /// </summary>
         /// <param name="archiveFileName">The file name of the archive.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="archiveFileName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="archiveFileName"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="archiveFileName"/> is empty or contains only whitespaces.</exception>
         public ArchiveCacheMethod(string archiveFileName)
         {

--- a/Gw2Sharp/WebApi/Caching/ICacheMethod.cs
+++ b/Gw2Sharp/WebApi/Caching/ICacheMethod.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.Caching
         /// </summary>
         /// <param name="category">The cache category.</param>
         /// <param name="id">The id.</param>
-        /// <returns>The task for this operation with a returned cached item if it exists and has not expired; <c>null</c> otherwise.</returns>
+        /// <returns>The task for this operation with a returned cached item if it exists and has not expired; <see langword="null"/> otherwise.</returns>
         Task<CacheItem?> TryGetAsync(string category, string id);
 
         /// <summary>

--- a/Gw2Sharp/WebApi/Exceptions/AuthorizationRequiredException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/AuthorizationRequiredException.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="error">The error.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/>, <paramref name="response"/> or <paramref name="error"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/>, <paramref name="response"/> or <paramref name="error"/> is <see langword="null"/>.</exception>
         public AuthorizationRequiredException(IWebApiRequest request, IWebApiResponse<ErrorObject> response, AuthorizationError error) :
             base(request, response, response?.Content.Message ?? string.Empty)
         {
@@ -34,7 +34,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The request.</param>
         /// <param name="response">The response.</param>
         /// <returns>The exception.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public static AuthorizationRequiredException CreateFromResponse(IWebApiRequest request, IWebApiResponse<ErrorObject> response)
         {
             if (request == null)

--- a/Gw2Sharp/WebApi/Exceptions/BadRequestException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/BadRequestException.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="error">The error.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public BadRequestException(IWebApiRequest request, IWebApiResponse<ErrorObject> response, BadRequestError error) :
             base(request, response, response?.Content.Message ?? string.Empty)
         {
@@ -34,7 +34,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The request.</param>
         /// <param name="response">The response.</param>
         /// <returns>The exception.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public static BadRequestException CreateFromResponse(IWebApiRequest request, IWebApiResponse<ErrorObject> response)
         {
             if (request == null)

--- a/Gw2Sharp/WebApi/Exceptions/InvalidAccessTokenException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/InvalidAccessTokenException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public InvalidAccessTokenException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, AuthorizationError.InvalidKey) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/ListTooLongException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/ListTooLongException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public ListTooLongException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, BadRequestError.ListTooLong) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/MembershipRequiredException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/MembershipRequiredException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public MembershipRequiredException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, AuthorizationError.MembershipRequired) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/MissingScopesException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/MissingScopesException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public MissingScopesException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, AuthorizationError.MissingScopes) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/NotFoundException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/NotFoundException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public NotFoundException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, response?.Content.Message ?? string.Empty) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/PageOutOfRangeException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/PageOutOfRangeException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public PageOutOfRangeException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, BadRequestError.PageOutOfRange) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/RequestCanceledException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/RequestCanceledException.cs
@@ -12,7 +12,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// Creates a new <see cref="RequestCanceledException" />.
         /// </summary>
         /// <param name="request">The original request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> is <see langword="null"/>.</exception>
         public RequestCanceledException(IWebApiRequest request) :
             base(request, "Request was canceled") { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/RequestException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/RequestException.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, string message) :
             base(request, message) { }
 
@@ -23,7 +23,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message) :
             base(request, response, message) { }
 
@@ -33,7 +33,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, string message, Exception? innerException) :
             base(request, message, innerException) { }
 
@@ -44,7 +44,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message, Exception innerException) :
             base(request, response, message, innerException) { }
     }
@@ -61,7 +61,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, string message) :
             this(request, null, message, null) { }
 
@@ -71,7 +71,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, IWebApiResponse<TResponse>? response, string message) :
             this(request, response, message, null) { }
 
@@ -81,7 +81,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, string message, Exception? innerException) :
             this(request, null, message, innerException) { }
 

--- a/Gw2Sharp/WebApi/Exceptions/RestrictedToGuildLeadersException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/RestrictedToGuildLeadersException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public RestrictedToGuildLeadersException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, AuthorizationError.AccessRestrictedToGuildLeaders) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/ServerErrorException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/ServerErrorException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public ServerErrorException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, response?.Content.Message ?? string.Empty) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/ServiceUnavailableException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/ServiceUnavailableException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public ServiceUnavailableException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, response?.Content.Message ?? string.Empty) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/TooManyRequestsException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/TooManyRequestsException.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public TooManyRequestsException(IWebApiRequest request, IWebApiResponse<ErrorObject> response) :
             base(request, response, response?.Content.Message ?? string.Empty) { }
     }

--- a/Gw2Sharp/WebApi/Exceptions/UnexpectedStatusException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/UnexpectedStatusException.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="response"/> is <see langword="null"/>.</exception>
         public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<string> response) :
             this(request, response, $"Unexpected HTTP status code: {(int?)response?.StatusCode ?? 0}") { }
 
@@ -23,7 +23,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<string>? response, string message) :
             base(request, response, message) { }
     }
@@ -47,7 +47,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public UnexpectedStatusException(IWebApiRequest request, IWebApiResponse<T>? response, string message) :
             base(request, response, message) { }
     }

--- a/Gw2Sharp/WebApi/Gw2WebApiBaseClient.cs
+++ b/Gw2Sharp/WebApi/Gw2WebApiBaseClient.cs
@@ -12,7 +12,7 @@ namespace Gw2Sharp.WebApi
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected Gw2WebApiBaseClient(IConnection connection, IGw2Client gw2Client)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));

--- a/Gw2Sharp/WebApi/Gw2WebApiClient.cs
+++ b/Gw2Sharp/WebApi/Gw2WebApiClient.cs
@@ -22,7 +22,7 @@ namespace Gw2Sharp.WebApi
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal Gw2WebApiClient(IConnection connection, IGw2Client gw2Client)
         {
             if (connection == null)

--- a/Gw2Sharp/WebApi/Http/HttpResponseInfo.cs
+++ b/Gw2Sharp/WebApi/Http/HttpResponseInfo.cs
@@ -71,14 +71,14 @@ namespace Gw2Sharp.WebApi.Http
         /// <summary>
         /// The cache age.
         /// This is returned by the value max-age in the header Cache-Control.
-        /// This value is <c>null</c> if the response didn't contain the appropriate header.
+        /// This value is <see langword="null"/> if the response didn't contain the appropriate header.
         /// </summary>
         public TimeSpan? CacheMaxAge { get; protected set; }
 
         /// <summary>
         /// The cache expiry date.
         /// This is returned by the header Expires.
-        /// This value is <c>null</c> if the response didn't contain the appropriate header.
+        /// This value is <see langword="null"/> if the response didn't contain the appropriate header.
         /// </summary>
         public DateTimeOffset? Expires { get; protected set; }
 

--- a/Gw2Sharp/WebApi/Http/HttpResponseStream.cs
+++ b/Gw2Sharp/WebApi/Http/HttpResponseStream.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.Http
         /// </summary>
         /// <param name="contentStream">The content stream.</param>
         /// <param name="cacheState">The cache state.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="contentStream"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="contentStream"/> is <see langword="null"/>.</exception>
         public HttpResponseStream(Stream contentStream, CacheState cacheState) : this(contentStream, null, cacheState, null, null) { }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="cacheState">The cache state.</param>
         /// <param name="requestHeaders">The original headers that were used in the web request.</param>
         /// <param name="responseHeaders">The response headers.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="contentStream"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="contentStream"/> is <see langword="null"/>.</exception>
         public HttpResponseStream(Stream contentStream, HttpStatusCode? statusCode, CacheState cacheState,
             IDictionary<string, string>? requestHeaders, IDictionary<string, string>? responseHeaders)
         {
@@ -49,7 +49,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="cacheState">The cache state.</param>
         /// <param name="requestHeaders">The original headers that were used in the web request.</param>
         /// <param name="responseHeaders">The response headers.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="contentStream"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="contentStream"/> is <see langword="null"/>.</exception>
         public HttpResponseStream(Stream contentStream, HttpStatusCode? statusCode, CacheState cacheState,
             IEnumerable<KeyValuePair<string, string>>? requestHeaders, IEnumerable<KeyValuePair<string, string>>? responseHeaders) :
             this(contentStream, statusCode, cacheState, requestHeaders?.ShallowCopy(), responseHeaders?.ShallowCopy())

--- a/Gw2Sharp/WebApi/Http/WebApiRequest.cs
+++ b/Gw2Sharp/WebApi/Http/WebApiRequest.cs
@@ -55,7 +55,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="connection">The connection.</param>
         /// <param name="gw2Client">The GW2 client.</param>
         /// <param name="requestHeaders">The request headers to use in the web request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="url"/>, <paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="url"/>, <paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         public WebApiRequest(Uri url, IConnection connection, IGw2Client gw2Client, IDictionary<string, string>? requestHeaders = default)
         {
             if (url is null)
@@ -89,7 +89,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="options">The request options.</param>
         /// <param name="connection">The connection.</param>
         /// <param name="gw2Client">The GW2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="options"/>, <paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/>, <paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         public WebApiRequest(WebApiRequestOptions options, IConnection connection, IGw2Client gw2Client)
         {
             this.Options = options ?? throw new ArgumentNullException(nameof(options));

--- a/Gw2Sharp/WebApi/Http/WebApiResponse.cs
+++ b/Gw2Sharp/WebApi/Http/WebApiResponse.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.Http
         /// </summary>
         /// <param name="content">The content.</param>
         /// <param name="cacheState">The cache state.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
         public WebApiResponse(string content, CacheState cacheState) : base(content, null, cacheState, null) { }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="statusCode">The status code.</param>
         /// <param name="cacheState">The cache state.</param>
         /// <param name="responseHeaders">The response headers.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
         public WebApiResponse(string content, HttpStatusCode? statusCode, CacheState cacheState, IDictionary<string, string>? responseHeaders)
             : base(content, statusCode, cacheState, responseHeaders) { }
 
@@ -36,7 +36,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="statusCode">The status code.</param>
         /// <param name="cacheState">The cache state.</param>
         /// <param name="responseHeaders">The response headers.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
         public WebApiResponse(string content, HttpStatusCode? statusCode, CacheState cacheState, IEnumerable<KeyValuePair<string, string>>? responseHeaders)
             : base(content, statusCode, cacheState, responseHeaders) { }
 
@@ -56,7 +56,7 @@ namespace Gw2Sharp.WebApi.Http
         /// </summary>
         /// <param name="content">The content.</param>
         /// <param name="cacheState">The cache state.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
         public WebApiResponse(T content, CacheState cacheState) : this(content, null, cacheState, null) { }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="statusCode">The status code.</param>
         /// <param name="cacheState">The cache state.</param>
         /// <param name="responseHeaders">The response headers.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
         public WebApiResponse(T content, HttpStatusCode? statusCode, CacheState cacheState, IDictionary<string, string>? responseHeaders)
         {
             this.Content = content ?? throw new ArgumentNullException(nameof(content));
@@ -84,7 +84,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <param name="statusCode">The status code.</param>
         /// <param name="cacheState">The cache state.</param>
         /// <param name="responseHeaders">The response headers.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="content"/> is <see langword="null"/>.</exception>
         public WebApiResponse(T content, HttpStatusCode? statusCode, CacheState cacheState, IEnumerable<KeyValuePair<string, string>>? responseHeaders) :
             this(content, statusCode, cacheState, responseHeaders?.ShallowCopy())
         { }

--- a/Gw2Sharp/WebApi/Render/Gw2WebApiRenderClient.cs
+++ b/Gw2Sharp/WebApi/Render/Gw2WebApiRenderClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.Render
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal Gw2WebApiRenderClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/ApiV2HttpResponseInfo.cs
+++ b/Gw2Sharp/WebApi/V2/ApiV2HttpResponseInfo.cs
@@ -56,21 +56,21 @@ namespace Gw2Sharp.WebApi.V2
         /// <summary>
         /// The rate limit limit.
         /// This is returned by the header X-Rate-Limit-Limit.
-        /// This value is <c>null</c> if the response didn't contain the appropriate header.
+        /// This value is <see langword="null"/> if the response didn't contain the appropriate header.
         /// </summary>
         public int? RateLimitLimit { get; protected set; }
 
         /// <summary>
         /// The result count.
         /// This is returned by the header X-Result-Count.
-        /// This value is <c>null</c> if the response didn't contain the appropriate header.
+        /// This value is <see langword="null"/> if the response didn't contain the appropriate header.
         /// </summary>
         public int? ResultCount { get; protected set; }
 
         /// <summary>
         /// The result total.
         /// This is returned by the header X-Result-Total.
-        /// This value is <c>null</c> if the response didn't contain the appropriate header.
+        /// This value is <see langword="null"/> if the response didn't contain the appropriate header.
         /// </summary>
         public int? ResultTotal { get; protected set; }
 
@@ -83,14 +83,14 @@ namespace Gw2Sharp.WebApi.V2
         /// <summary>
         /// The page size.
         /// This is returned by the header X-Page-Size.
-        /// This value is <c>null</c> if the response didn't contain the appropriate header.
+        /// This value is <see langword="null"/> if the response didn't contain the appropriate header.
         /// </summary>
         public int? PageSize { get; protected set; }
 
         /// <summary>
         /// The page total.
         /// This is returned by the header X-Page-Total.
-        /// This value is <c>null</c> if the response didn't contain the appropriate header.
+        /// This value is <see langword="null"/> if the response didn't contain the appropriate header.
         /// </summary>
         public int? PageTotal { get; protected set; }
     }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountAchievementsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountAchievementsClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountAchievementsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountBankClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountBankClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountBankClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountBuildStorageClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountBuildStorageClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountBuildStorageClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountClient.cs
@@ -50,7 +50,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountDailyCraftingClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountDailyCraftingClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountDailyCraftingClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountDungeonsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountDungeonsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountDungeonsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountDyesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountDyesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountDyesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountEmotesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountEmotesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountEmotesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountFinishersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountFinishersClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountFinishersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountGlidersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountGlidersClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountGlidersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountHomeCatsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountHomeCatsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountHomeCatsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountHomeClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountHomeClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountHomeClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountHomeNodesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountHomeNodesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountHomeNodesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountInventoryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountInventoryClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountInventoryClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountLegendaryArmoryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountLegendaryArmoryClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountLegendaryArmoryClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountLuckClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountLuckClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountLuckClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMailCarriersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMailCarriersClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMailCarriersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMapChestsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMapChestsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMapChestsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMasteriesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMasteriesClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMasteriesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMasteryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMasteryClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMasteryClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMasteryPointsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMasteryPointsClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMasteryPointsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMaterialsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMaterialsClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMaterialsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMinisClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMinisClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMinisClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMountsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMountsClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMountsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMountsSkinsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMountsSkinsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMountsSkinsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountMountsTypesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountMountsTypesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountMountsTypesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountNoveltiesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountNoveltiesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountNoveltiesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountOutfitsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountOutfitsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountOutfitsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountProgressionClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountProgressionClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountProgressionClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountPvpClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountPvpClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountPvpClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountPvpHeroesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountPvpHeroesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountPvpHeroesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountRaidsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountRaidsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountRaidsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountRecipesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountRecipesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountRecipesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountSkinsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountSkinsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountSkinsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountTitlesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountTitlesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountTitlesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountWalletClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountWalletClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountWalletClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Account/AccountWorldBossesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/AccountWorldBossesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AccountWorldBossesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsCategoriesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsCategoriesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AchievementsCategoriesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsClient.cs
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AchievementsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsDailyClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsDailyClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AchievementsDailyClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsDailyTomorrowClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsDailyTomorrowClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AchievementsDailyTomorrowClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsGroupsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Achievements/AchievementsGroupsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal AchievementsGroupsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Backstory/BackstoryAnswersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Backstory/BackstoryAnswersClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal BackstoryAnswersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Backstory/BackstoryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Backstory/BackstoryClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal BackstoryClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Backstory/BackstoryQuestionsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Backstory/BackstoryQuestionsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal BackstoryQuestionsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/BaseEndpointBlobClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseEndpointBlobClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="replaceSegments">The path segments to replace.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">
         /// The client implements an invalid combination of <see cref="IEndpointClient"/> interfaces,
         /// or the number of replace segments does not equal the number of path segments given by <see cref="EndpointPathSegmentAttribute"/>.

--- a/Gw2Sharp/WebApi/V2/Clients/BaseEndpointBulkAllClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseEndpointBulkAllClient.cs
@@ -21,7 +21,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="replaceSegments">The path segments to replace.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">
         /// The client implements an invalid combination of <see cref="IEndpointClient"/> interfaces,
         /// or the number of replace segments does not equal the number of path segments given by <see cref="EndpointPathSegmentAttribute"/>.

--- a/Gw2Sharp/WebApi/V2/Clients/BaseEndpointBulkClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseEndpointBulkClient.cs
@@ -21,7 +21,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="replaceSegments">The path segments to replace.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">
         /// The client implements an invalid combination of <see cref="IEndpointClient"/> interfaces,
         /// or the number of replace segments does not equal the number of path segments given by <see cref="EndpointPathSegmentAttribute"/>.

--- a/Gw2Sharp/WebApi/V2/Clients/BaseEndpointClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseEndpointClient.cs
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="replaceSegments">The path segments to replace.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">
         /// The client implements an invalid combination of <see cref="IEndpointClient"/> interfaces,
         /// or the number of replace segments does not equal the number of path segments given by <see cref="EndpointPathSegmentAttribute"/>.

--- a/Gw2Sharp/WebApi/V2/Clients/BaseEndpointPaginatedBlobClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseEndpointPaginatedBlobClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="replaceSegments">The path segments to replace.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">
         /// The client implements an invalid combination of <see cref="IEndpointClient"/> interfaces,
         /// or the number of replace segments does not equal the number of path segments given by <see cref="EndpointPathSegmentAttribute"/>.

--- a/Gw2Sharp/WebApi/V2/Clients/Build/BuildClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Build/BuildClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal BuildClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/BaseCharactersSubBlobClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/BaseCharactersSubBlobClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="characterName">The character name.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected BaseCharactersSubBlobClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/BaseCharactersSubBulkClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/BaseCharactersSubBulkClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="characterName">The character name.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected BaseCharactersSubBulkClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CharactersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdBackstoryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdBackstoryClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdBackstoryClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdBuildTabsActiveClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdBuildTabsActiveClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="characterName">The character name.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         public CharactersIdBuildTabsActiveClient(IConnection connection, IGw2Client gw2Client, string characterName)
             : base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdBuildTabsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdBuildTabsClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdBuildTabsClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdClient.cs
@@ -31,7 +31,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name that's used for all character requests.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdCoreClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdCoreClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdCoreClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdCraftingClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdCraftingClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdCraftingClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdEquipmentClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsActiveClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsActiveClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="characterName">The character name.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         public CharactersIdEquipmentTabsActiveClient(IConnection connection, IGw2Client gw2Client, string characterName)
             : base(connection, gw2Client, characterName)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdEquipmentTabsClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdEquipmentTabsClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdHeroPointsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdHeroPointsClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdHeroPointsClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdInventoryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdInventoryClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdInventoryClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdQuestsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdQuestsClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdQuestsClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdRecipesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdRecipesClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdRecipesClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdSabClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdSabClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdSabClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdTrainingClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Characters/CharactersIdTrainingClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="characterName">The character name.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/>, <paramref name="gw2Client"/> or <paramref name="characterName"/> is <see langword="null"/>.</exception>
         protected internal CharactersIdTrainingClient(IConnection connection, IGw2Client gw2Client, string characterName) :
             base(connection, gw2Client, characterName)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Colors/ColorsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Colors/ColorsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ColorsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceDeliveryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceDeliveryClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceDeliveryClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceExchangeClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeCoinsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeCoinsClient.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceExchangeCoinsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeCoinsQuantityClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeCoinsQuantityClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="quantity">The amount of coins to exchange.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         public CommerceExchangeCoinsQuantityClient(IConnection connection, IGw2Client gw2Client, int quantity) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeGemsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeGemsClient.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceExchangeGemsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeGemsQuantityClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceExchangeGemsQuantityClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="quantity">The amount of gems to exchange.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         public CommerceExchangeGemsQuantityClient(IConnection connection, IGw2Client gw2Client, int quantity) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceListingsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceListingsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceListingsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommercePricesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommercePricesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommercePricesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceTransactionsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsCurrentBuysClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsCurrentBuysClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceTransactionsCurrentBuysClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsCurrentClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsCurrentClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceTransactionsCurrentClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsCurrentSellsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsCurrentSellsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceTransactionsCurrentSellsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsHistoryBuysClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsHistoryBuysClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceTransactionsHistoryBuysClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsHistoryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsHistoryClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceTransactionsHistoryClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsHistorySellsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Commerce/CommerceTransactionsHistorySellsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal CommerceTransactionsHistorySellsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="continentId">The continent id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsClient(IConnection connection, IGw2Client gw2Client, int continentId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsIdClient.cs
@@ -23,7 +23,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="continentId">The continent id.</param>
         /// <param name="floorId">The floor id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsIdClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsClient.cs
@@ -22,7 +22,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="continentId">The continent id.</param>
         /// <param name="floorId">The floor id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsRegionsClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsIdClient.cs
@@ -26,7 +26,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="continentId">The continent id.</param>
         /// <param name="floorId">The floor id.</param>
         /// <param name="regionId">The region id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsRegionsIdClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId, int regionId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture), regionId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsClient.cs
@@ -25,7 +25,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="continentId">The continent id.</param>
         /// <param name="floorId">The floor id.</param>
         /// <param name="regionId">The region id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsRegionsMapsClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId, int regionId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture), regionId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsIdClient.cs
@@ -31,7 +31,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="floorId">The floor id.</param>
         /// <param name="regionId">The region id.</param>
         /// <param name="mapId">The map id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsRegionsMapsIdClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId, int regionId, int mapId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture), regionId.ToString(CultureInfo.InvariantCulture), mapId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsPoisClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsPoisClient.cs
@@ -28,7 +28,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="floorId">The floor id.</param>
         /// <param name="regionId">The region id.</param>
         /// <param name="mapId">The map id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsRegionsMapsPoisClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId, int regionId, int mapId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture), regionId.ToString(CultureInfo.InvariantCulture), mapId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsSectorsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsSectorsClient.cs
@@ -28,7 +28,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="floorId">The floor id.</param>
         /// <param name="regionId">The region id.</param>
         /// <param name="mapId">The map id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsRegionsMapsSectorsClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId, int regionId, int mapId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture), regionId.ToString(CultureInfo.InvariantCulture), mapId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsTasksClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsFloorsRegionsMapsTasksClient.cs
@@ -28,7 +28,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="floorId">The floor id.</param>
         /// <param name="regionId">The region id.</param>
         /// <param name="mapId">The map id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsFloorsRegionsMapsTasksClient(IConnection connection, IGw2Client gw2Client, int continentId, int floorId, int regionId, int mapId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture), floorId.ToString(CultureInfo.InvariantCulture), regionId.ToString(CultureInfo.InvariantCulture), mapId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Continents/ContinentsIdClient.cs
@@ -20,7 +20,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="continentId">The continent id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal ContinentsIdClient(IConnection connection, IGw2Client gw2Client, int continentId) :
             base(connection, gw2Client, continentId.ToString(CultureInfo.InvariantCulture))
         {

--- a/Gw2Sharp/WebApi/V2/Clients/CreateSubtoken/CreateSubtokenClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/CreateSubtoken/CreateSubtokenClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal CreateSubtokenClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Currencies/CurrenciesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Currencies/CurrenciesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal CurrenciesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/DailyCrafting/DailyCraftingClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/DailyCrafting/DailyCraftingClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal DailyCraftingClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Dungeons/DungeonsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Dungeons/DungeonsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal DungeonsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Emblem/EmblemBackgroundsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Emblem/EmblemBackgroundsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal EmblemBackgroundsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Emblem/EmblemClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Emblem/EmblemClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal EmblemClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Emblem/EmblemForegroundsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Emblem/EmblemForegroundsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal EmblemForegroundsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Emotes/EmotesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Emotes/EmotesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal EmotesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/EndpointBulkIdNameAttribute.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/EndpointBulkIdNameAttribute.cs
@@ -32,7 +32,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="id">The name of the query parameter that acts as the id.</param>
         /// <param name="ids">The name of the query parameter that acts as the ids.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="id"/> or <paramref name="ids"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="id"/> or <paramref name="ids"/> is <see langword="null"/>.</exception>
         public EndpointBulkIdNameAttribute(string id, string ids)
         {
             this.Id = id ?? throw new ArgumentNullException(nameof(id));
@@ -43,7 +43,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// Creates a new instance of the <see cref="EndpointBulkIdNameAttribute"/> class.
         /// </summary>
         /// <param name="objectId">The name of the property in the object returned by the API that acts as the id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="objectId"/>is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="objectId"/>is <see langword="null"/>.</exception>
         public EndpointBulkIdNameAttribute(string objectId)
         {
             this.ObjectId = objectId ?? throw new ArgumentNullException(nameof(objectId));
@@ -55,7 +55,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="id">The name of the query parameter that acts as the id.</param>
         /// <param name="ids">The name of the query parameter that acts as the ids.</param>
         /// <param name="objectId">The name of the property in the object returned by the API that acts as the id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="id"/> or <paramref name="ids"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="id"/> or <paramref name="ids"/> is <see langword="null"/>.</exception>
         public EndpointBulkIdNameAttribute(string id, string ids, string objectId)
         {
             this.Id = id ?? throw new ArgumentNullException(nameof(id));

--- a/Gw2Sharp/WebApi/V2/Clients/EndpointPathAttribute.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/EndpointPathAttribute.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// Creates a new instance of the <see cref="EndpointPathAttribute"/> class.
         /// </summary>
         /// <param name="endpointPath">The endpoint path.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="endpointPath"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="endpointPath"/> is <see langword="null"/>.</exception>
         public EndpointPathAttribute(string endpointPath)
         {
             this.EndpointPath = endpointPath ?? throw new ArgumentNullException(nameof(endpointPath));

--- a/Gw2Sharp/WebApi/V2/Clients/EndpointPathSegmentAttribute.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/EndpointPathSegmentAttribute.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="pathSegment">The path segment to replace.</param>
         /// <param name="order">The order of the passed parameter that is used when replacing the path segment.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="pathSegment"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pathSegment"/> is <see langword="null"/>.</exception>
         public EndpointPathSegmentAttribute(string pathSegment, int order)
         {
             this.PathSegment = pathSegment ?? throw new ArgumentNullException(nameof(pathSegment));

--- a/Gw2Sharp/WebApi/V2/Clients/EndpointQueryParameterAttribute.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/EndpointQueryParameterAttribute.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// Creates a new instance of the <see cref="EndpointQueryParameterAttribute"/> class.
         /// </summary>
         /// <param name="parameterName">The query parameter name.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="parameterName"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="parameterName"/> is <see langword="null"/>.</exception>
         public EndpointQueryParameterAttribute(string parameterName)
         {
             this.ParameterName = parameterName ?? throw new ArgumentNullException(nameof(parameterName));

--- a/Gw2Sharp/WebApi/V2/Clients/EndpointSchemaVersionAttribute.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/EndpointSchemaVersionAttribute.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// Creates a new instance of the <see cref="EndpointSchemaVersionAttribute"/> class.
         /// </summary>
         /// <param name="schemaVersion">The schema version.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="schemaVersion"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="schemaVersion"/> is <see langword="null"/>.</exception>
         public EndpointSchemaVersionAttribute(string schemaVersion)
         {
             this.SchemaVersion = schemaVersion ?? throw new ArgumentNullException(nameof(schemaVersion));

--- a/Gw2Sharp/WebApi/V2/Clients/Files/FilesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Files/FilesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal FilesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Finishers/FinishersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Finishers/FinishersClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal FinishersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Gliders/GlidersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Gliders/GlidersClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal GlidersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/BaseGuildSubClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/BaseGuildSubClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected BaseGuildSubClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId.ToString())
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal GuildClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdClient.cs
@@ -26,7 +26,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId.ToString())
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdLogClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdLogClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdLogClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdMembersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdMembersClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdMembersClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdRanksClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdRanksClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdRanksClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdStashClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdStashClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdStashClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdStorageClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdStorageClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdStorageClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdTeamsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdTeamsClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdTeamsClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdTreasuryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdTreasuryClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal GuildIdTreasuryClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdUpgradesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildIdUpgradesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="guildId">The guild id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         public GuildIdUpgradesClient(IConnection connection, IGw2Client gw2Client, Guid guildId) :
             base(connection, gw2Client, guildId)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildPermissionsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildPermissionsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal GuildPermissionsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildSearchClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildSearchClient.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal GuildSearchClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildSearchNameClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildSearchNameClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="name">The guild name.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         public GuildSearchNameClient(IConnection connection, IGw2Client gw2Client, string name) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/GuildUpgradesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/GuildUpgradesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal GuildUpgradesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Guild/IGuildIdLogClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Guild/IGuildIdLogClient.cs
@@ -17,14 +17,14 @@ namespace Gw2Sharp.WebApi.V2.Clients
 
         /// <summary>
         /// The parameter for requesting logs with an id higher than the given id.
-        /// Use <c>null</c> to unset the parameter.
+        /// Use <see langword="null"/> to unset the parameter.
         /// </summary>
         int? ParamSince { get; }
 
         /// <summary>
         /// Sets the parameter for requesting logs with an id higher than the given id.
         /// </summary>
-        /// <param name="since">The id. Use <c>null</c> to unset the parameter.</param>
+        /// <param name="since">The id. Use <see langword="null"/> to unset the parameter.</param>
         /// <returns><c>this</c> to allow method chaining.</returns>
         IGuildIdLogClient Since(int? since);
     }

--- a/Gw2Sharp/WebApi/V2/Clients/Home/HomeCatsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Home/HomeCatsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal HomeCatsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Home/HomeClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Home/HomeClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal HomeClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Home/HomeNodesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Home/HomeNodesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal HomeNodesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/IBulkAliasExpandableClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/IBulkAliasExpandableClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="id">The entry id.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The entry.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="id"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="id"/> is <see langword="null"/>.</exception>
         Task<TObject> GetAsync(TId id, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="ids">The entry ids.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The entries.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="ids"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="ids"/> is <see langword="null"/>.</exception>
         Task<IReadOnlyList<TObject>> ManyAsync(IEnumerable<TId> ids, CancellationToken cancellationToken = default);
     }
 }

--- a/Gw2Sharp/WebApi/V2/Clients/IBulkExpandableClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/IBulkExpandableClient.cs
@@ -20,7 +20,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="id">The entry id.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The entry.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="id"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="id"/> is <see langword="null"/>.</exception>
         Task<TObject> GetAsync(TId id, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="ids">The entry ids.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The entries.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="ids"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="ids"/> is <see langword="null"/>.</exception>
         Task<IReadOnlyList<TObject>> ManyAsync(IEnumerable<TId> ids, CancellationToken cancellationToken = default);
     }
 }

--- a/Gw2Sharp/WebApi/V2/Clients/Items/ItemsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Items/ItemsClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal ItemsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Itemstats/ItemstatsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Itemstats/ItemstatsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal ItemstatsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/LegendaryArmory/LegendaryArmoryClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/LegendaryArmory/LegendaryArmoryClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal LegendaryArmoryClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Legends/LegendsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Legends/LegendsClient.cs
@@ -20,7 +20,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal LegendsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/MailCarriers/MailCarriersClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/MailCarriers/MailCarriersClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MailCarriersClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/MapChests/MapChestsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/MapChests/MapChestsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MapChestsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Maps/MapsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Maps/MapsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MapsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Masteries/MasteriesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Masteries/MasteriesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MasteriesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Materials/MaterialsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Materials/MaterialsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MaterialsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Minis/MinisClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Minis/MinisClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MinisClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Mounts/MountsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Mounts/MountsClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MountsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Mounts/MountsSkinsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Mounts/MountsSkinsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MountsSkinsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Mounts/MountsTypesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Mounts/MountsTypesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal MountsTypesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Novelties/NoveltiesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Novelties/NoveltiesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal NoveltiesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Outfits/OutfitsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Outfits/OutfitsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal OutfitsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pets/PetsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pets/PetsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PetsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Professions/ProfessionsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Professions/ProfessionsClient.cs
@@ -20,7 +20,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal ProfessionsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpAmuletsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpAmuletsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpAmuletsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpClient.cs
@@ -21,7 +21,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpGamesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpGamesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpGamesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpHeroesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpHeroesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpHeroesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpRanksClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpRanksClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpRanksClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpSeasonsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsIdClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="seasonId">The PvP season id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         public PvpSeasonsIdClient(IConnection connection, IGw2Client gw2Client, Guid seasonId) :
              base(connection, gw2Client, seasonId.ToString())
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsLeaderboardsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsLeaderboardsClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="seasonId">The PvP season id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         public PvpSeasonsLeaderboardsClient(IConnection connection, IGw2Client gw2Client, Guid seasonId) :
             base(connection, gw2Client, seasonId.ToString())
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsLeaderboardsIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsLeaderboardsIdClient.cs
@@ -20,7 +20,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="seasonId">The PvP season id.</param>
         /// <param name="leaderboardId">The PvP season leaderboard id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         public PvpSeasonsLeaderboardsIdClient(IConnection connection, IGw2Client gw2Client, Guid seasonId, string leaderboardId) :
             base(connection, gw2Client, seasonId.ToString(), leaderboardId)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsLeaderboardsRegionIdClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpSeasonsLeaderboardsRegionIdClient.cs
@@ -24,7 +24,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="seasonId">The PvP season id.</param>
         /// <param name="leaderboardId">The PvP season leaderboard id.</param>
         /// <param name="regionId">The PvP season leaderboard region id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         public PvpSeasonsLeaderboardsRegionIdClient(IConnection connection, IGw2Client gw2Client, Guid seasonId, string leaderboardId, string regionId) :
             base(connection, gw2Client, seasonId.ToString(), leaderboardId, regionId)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpStandingsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpStandingsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpStandingsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpStatsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Pvp/PvpStatsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal PvpStatsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Quaggans/QuaggansClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Quaggans/QuaggansClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal QuaggansClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Quests/QuestsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Quests/QuestsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal QuestsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Races/RacesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Races/RacesClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal RacesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Raids/RaidsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Raids/RaidsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal RaidsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal RecipesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesSearchClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesSearchClient.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal RecipesSearchClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesSearchInputClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesSearchInputClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="input">The input item id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal RecipesSearchInputClient(IConnection connection, IGw2Client gw2Client, int input) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesSearchOutputClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Recipes/RecipesSearchOutputClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="output">The output item id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal RecipesSearchOutputClient(IConnection connection, IGw2Client gw2Client, int output) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Skills/SkillsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Skills/SkillsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal SkillsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Skins/SkinsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Skins/SkinsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal SkinsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Specializations/SpecializationsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Specializations/SpecializationsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal SpecializationsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Stories/StoriesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Stories/StoriesClient.cs
@@ -16,7 +16,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal StoriesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Stories/StoriesSeasonsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Stories/StoriesSeasonsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal StoriesSeasonsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Titles/TitlesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Titles/TitlesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal TitlesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/TokenInfo/TokeninfoClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/TokenInfo/TokeninfoClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal TokenInfoClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Traits/TraitsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Traits/TraitsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal TraitsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/WorldBosses/WorldBossesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/WorldBosses/WorldBossesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WorldBossesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Worlds/WorldsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Worlds/WorldsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WorldsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwAbilitiesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwAbilitiesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwAbilitiesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwClient.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal WvwClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesClient.cs
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesOverviewClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesOverviewClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesOverviewClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesOverviewWorldClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesOverviewWorldClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="world">The world id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesOverviewWorldClient(IConnection connection, IGw2Client gw2Client, int world) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesScoresClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesScoresClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesScoresClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesScoresWorldClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesScoresWorldClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="world">The world id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesScoresWorldClient(IConnection connection, IGw2Client gw2Client, int world) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesStatsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesStatsClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesStatsClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesStatsWorldClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesStatsWorldClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="world">The world id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesStatsWorldClient(IConnection connection, IGw2Client gw2Client, int world) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesWorldClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwMatchesWorldClient.cs
@@ -17,7 +17,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
         /// <param name="world">The world id.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwMatchesWorldClient(IConnection connection, IGw2Client gw2Client, int world) :
             base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwObjectivesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwObjectivesClient.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwObjectivesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwRanksClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwRanksClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwRanksClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwUpgradesClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Wvw/WvwUpgradesClient.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> is <see langword="null"/>.</exception>
         protected internal WvwUpgradesClient(IConnection connection, IGw2Client gw2Client) :
             base(connection, gw2Client)
         { }

--- a/Gw2Sharp/WebApi/V2/Gw2WebApiV2Client.cs
+++ b/Gw2Sharp/WebApi/V2/Gw2WebApiV2Client.cs
@@ -69,7 +69,7 @@ namespace Gw2Sharp.WebApi.V2
         /// </summary>
         /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="connection"/> or <paramref name="gw2Client"/> is <see langword="null"/>.</exception>
         protected internal Gw2WebApiV2Client(IConnection connection, IGw2Client gw2Client)
             : base(connection, gw2Client)
         {

--- a/Gw2Sharp/WebApi/V2/IApiV2Object.cs
+++ b/Gw2Sharp/WebApi/V2/IApiV2Object.cs
@@ -9,7 +9,7 @@ namespace Gw2Sharp.WebApi.V2
     {
         /// <summary>
         /// Gets or sets the associated HTTP response information.
-        /// When the request info isn't available, this value is <c>null</c>.
+        /// When the request info isn't available, this value is <see langword="null"/>.
         /// </summary>
         [JsonIgnore]
         ApiV2HttpResponseInfo? HttpResponseInfo { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/Account/AccountAchievement.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Account/AccountAchievement.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// Gets the unlocked achievement bits.
-        /// If the achievement does not support bits, this value is <c>null</c>.
+        /// If the achievement does not support bits, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int>? Bits { get; set; }
 
@@ -36,13 +36,13 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The number of times the achievement has been repeatedly completed.
-        /// If the achievement is not repeatable, this value is <c>null</c>.
+        /// If the achievement is not repeatable, this value is <see langword="null"/>.
         /// </summary>
         public int? Repeated { get; set; }
 
         /// <summary>
         /// Whether or not the achievement is unlocked.
-        /// If the achievement is does not support locking, this value is <c>null</c> and the achievement is not locked.
+        /// If the achievement is does not support locking, this value is <see langword="null"/> and the achievement is not locked.
         /// </summary>
         public bool? Unlocked { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Account/AccountFinisher.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Account/AccountFinisher.cs
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The number of finishers remaining.
-        /// If the finisher is not temporary, this value is <c>null</c>.
+        /// If the finisher is not temporary, this value is <see langword="null"/>.
         /// </summary>
         public int? Quantity { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Account/AccountItem.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Account/AccountItem.cs
@@ -20,46 +20,46 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The number of charges remaining.
-        /// If the item does not support charges, this value is <c>null</c>.
+        /// If the item does not support charges, this value is <see langword="null"/>.
         /// </summary>
         public int? Charges { get; set; }
 
         /// <summary>
         /// The skin id.
-        /// If the item is not skinnable or has the original skin, this value is <c>null</c>.
+        /// If the item is not skinnable or has the original skin, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skins"/>.
         /// </summary>
         public int? Skin { get; set; }
 
         /// <summary>
         /// The selected stats for the equipped item.
-        /// If the item has no selectable item stats, this value is <c>null</c>.
+        /// If the item has no selectable item stats, this value is <see langword="null"/>.
         /// </summary>
         public EquipmentItemStats? Stats { get; set; }
 
         /// <summary>
         /// The list of upgrades applied to the item.
-        /// If the item does not have any upgrades, this value is <c>null</c>.
+        /// If the item does not have any upgrades, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public IReadOnlyList<int>? Upgrades { get; set; }
 
         /// <summary>
         /// The list of infusions applied to the item.
-        /// If the item does not have any upgrades, this value is <c>null</c>.
+        /// If the item does not have any upgrades, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public IReadOnlyList<int>? Infusions { get; set; }
 
         /// <summary>
         /// The current binding of the item.
-        /// If the item is not bound, this value is <c>null</c>.
+        /// If the item is not bound, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<ItemBinding>? Binding { get; set; }
 
         /// <summary>
         /// The name of the character to which the item is bound.
-        /// If the item is not character bound (see <see cref="Binding"/>), this value is <c>null</c>.
+        /// If the item is not character bound (see <see cref="Binding"/>), this value is <see langword="null"/>.
         /// </summary>
         public string? BoundTo { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Account/AccountMaterial.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Account/AccountMaterial.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The material binding.
-        /// If the material is not bound, this value is <c>null</c>.
+        /// If the material is not bound, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<ItemBinding>? Binding { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Achievement/Achievement.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Achievement/Achievement.cs
@@ -49,32 +49,32 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// Gets the achievement bits.
-        /// If the achievement does not have any bits, this value is <c>null</c>.
+        /// If the achievement does not have any bits, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<AchievementBit>? Bits { get; set; }
 
         /// <summary>
         /// The achievement tiers.
-        /// If the achievement does not have any tiers, this value is <c>null</c>.
+        /// If the achievement does not have any tiers, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<AchievementTier>? Tiers { get; set; }
 
         /// <summary>
         /// The achievement prerequisites.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Achievements"/>.
-        /// If the achievement does not have any prerequisites, this value is <c>null</c>.
+        /// If the achievement does not have any prerequisites, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int>? Prerequisites { get; set; }
 
         /// <summary>
         /// The maximum amount of achievement points that can be awarded from repeatedly completing the achievement.
-        /// If the achievement is not repeatable, this value is <c>null</c>.
+        /// If the achievement is not repeatable, this value is <see langword="null"/>.
         /// </summary>
         public int? PointCap { get; set; }
 
         /// <summary>
         /// The achievement rewards.
-        /// If the achievement does not have any rewards, this value is <c>null</c>.
+        /// If the achievement does not have any rewards, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<AchievementReward>? Rewards { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Achievement/AchievementDaily.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Achievement/AchievementDaily.cs
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The daily achievement game access requirement.
-        /// If there are no game access requirements, this value is <c>null</c>.
+        /// If there are no game access requirements, this value is <see langword="null"/>.
         /// </summary>
         public AchievementDailyAccess? RequiredAccess { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ApiEnum.cs
@@ -52,7 +52,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// Creates a new API enum.
         /// </summary>
         /// <param name="value">The enum value.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
         public ApiEnum(T value) : this(value, Enum.GetName(typeof(T), value)) { }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The raw enum value.
-        /// If the original value was <c>undefined</c> or <c>null</c>, this value is <c>null</c>.
+        /// If the original value was <c>undefined</c> or <see langword="null"/>, this value is <see langword="null"/>.
         /// </summary>
         public string? RawValue { get; }
 

--- a/Gw2Sharp/WebApi/V2/Models/ApiFlags.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ApiFlags.cs
@@ -22,7 +22,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// Creates new API flags.
         /// </summary>
         /// <param name="list">The list of enum values.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
         public ApiFlags(IEnumerable<ApiEnum<T>> list)
         {
             this.List = list?.ToList()?.AsReadOnly() ?? throw new ArgumentNullException(nameof(list));
@@ -34,7 +34,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// Used internally by <see cref="ApiFlagsConverter"/>.
         /// </summary>
         /// <param name="list">The list of enum values.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="list"/> is <see langword="null"/>.</exception>
         internal ApiFlags(IEnumerable<object> list) :
             this(list?.Cast<ApiEnum<T>>() ?? throw new ArgumentNullException(nameof(list)))
         { }

--- a/Gw2Sharp/WebApi/V2/Models/Backstory/BackstoryAnswer.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Backstory/BackstoryAnswer.cs
@@ -36,14 +36,14 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The list of races to which the backstory answer applies to.
-        /// If the backstory answer applies to all races, this value is <c>null</c>.
+        /// If the backstory answer applies to all races, this value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Races"/>.
         /// </summary>
         public IReadOnlyList<string>? Races { get; set; }
 
         /// <summary>
         /// The list of professions to which the backstory answer applies to.
-        /// If the backstory answer applies to all professions, this value is <c>null</c>.
+        /// If the backstory answer applies to all professions, this value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Professions"/>.
         /// </summary>
         public IReadOnlyList<string>? Professions { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/Backstory/BackstoryQuestion.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Backstory/BackstoryQuestion.cs
@@ -37,14 +37,14 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The list of races to which the backstory question applies to.
-        /// If the backstory question applies to all races, this value is <c>null</c>.
+        /// If the backstory question applies to all races, this value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Races"/>.
         /// </summary>
         public IReadOnlyList<string>? Races { get; set; }
 
         /// <summary>
         /// The list of professions to which the backstory question applies to.
-        /// If the backstory question applies to all professions, this value is <c>null</c>.
+        /// If the backstory question applies to all professions, this value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Professions"/>.
         /// </summary>
         public IReadOnlyList<string>? Professions { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/BuildTemplate.cs
+++ b/Gw2Sharp/WebApi/V2/Models/BuildTemplate.cs
@@ -10,14 +10,14 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The build template name.
-        /// If the build template isn't set, this value is <c>null</c>.
+        /// If the build template isn't set, this value is <see langword="null"/>.
         /// </summary>
         public string? Name { get; set; }
 
         /// <summary>
         /// The build template profession.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Professions"/>.
-        /// If the build template isn't set, this value is <c>null</c>.
+        /// If the build template isn't set, this value is <see langword="null"/>.
         /// </summary>
         public string? Profession { get; set; }
 
@@ -38,22 +38,22 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The pet skills.
-        /// If the profession is not a ranger, this value is <c>null</c>.
+        /// If the profession is not a ranger, this value is <see langword="null"/>.
         /// </summary>
         public BuildTemplatePets Pets { get; set; } = new BuildTemplatePets();
 
         /// <summary>
         /// The list of revenant skills.
-        /// If the profession is not a revenant, this value is <c>null</c>.
-        /// If a legend is not selected in a specific slot, that element is <c>null</c>.
+        /// If the profession is not a revenant, this value is <see langword="null"/>.
+        /// If a legend is not selected in a specific slot, that element is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Legends"/>.
         /// </summary>
         public IReadOnlyList<string?>? Legends { get; set; }
 
         /// <summary>
         /// The list of aquatic revenant skills.
-        /// If the profession is not a revenant, this value is <c>null</c>.
-        /// If a legend is not selected in a specific slot, that element is <c>null</c>.
+        /// If the profession is not a revenant, this value is <see langword="null"/>.
+        /// If a legend is not selected in a specific slot, that element is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Legends"/>.
         /// </summary>
         public IReadOnlyList<string?>? AquaticLegends { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/BuildTemplatePets.cs
+++ b/Gw2Sharp/WebApi/V2/Models/BuildTemplatePets.cs
@@ -10,13 +10,13 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The terrestrial pets.
-        /// If a pet is not selected in a specific slot, that element is <c>null</c>.
+        /// If a pet is not selected in a specific slot, that element is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int?> Terrestrial { get; set; } = Array.Empty<int?>();
 
         /// <summary>
         /// The aquatic pets.
-        /// If a pet is not selected in a specific slot, that element is <c>null</c>.
+        /// If a pet is not selected in a specific slot, that element is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int?> Aquatic { get; set; } = Array.Empty<int?>();
     }

--- a/Gw2Sharp/WebApi/V2/Models/BuildTemplateSkills.cs
+++ b/Gw2Sharp/WebApi/V2/Models/BuildTemplateSkills.cs
@@ -10,21 +10,21 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The healing skill.
-        /// If no healing skill is selected, this value is <c>null</c>.
+        /// If no healing skill is selected, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
         /// </summary>
         public int? Heal { get; set; }
 
         /// <summary>
         /// The list of utility skills.
-        /// If a utility skill is not selected in a specific slot, that element is <c>null</c>.
+        /// If a utility skill is not selected in a specific slot, that element is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
         /// </summary>
         public IReadOnlyList<int?> Utilities { get; set; } = Array.Empty<int?>();
 
         /// <summary>
         /// The elite skill.
-        /// If no elite skill is selected, this value is <c>null</c>.
+        /// If no elite skill is selected, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
         /// </summary>
         public int? Elite { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/BuildTemplateSpecialization.cs
+++ b/Gw2Sharp/WebApi/V2/Models/BuildTemplateSpecialization.cs
@@ -10,14 +10,14 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The specialization id.
-        /// If no specialization is selected, this value is <c>null</c>.
+        /// If no specialization is selected, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Specializations"/>.
         /// </summary>
         public int? Id { get; set; }
 
         /// <summary>
         /// The list of major traits.
-        /// If a trait is not selected in a specific slot, that element is <c>null</c>.
+        /// If a trait is not selected in a specific slot, that element is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Traits"/>.
         /// </summary>
         public IReadOnlyList<int?> Traits { get; set; } = Array.Empty<int?>();

--- a/Gw2Sharp/WebApi/V2/Models/CastableTypeAttribute.cs
+++ b/Gw2Sharp/WebApi/V2/Models/CastableTypeAttribute.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// Creates a new instance of the <see cref="CastableTypeAttribute"/> class.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><paramref name="value"/> or <paramref name="objectType"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> or <paramref name="objectType"/> is <see langword="null"/>.</exception>
         public CastableTypeAttribute(object value, Type objectType)
         {
             if (value == null)

--- a/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/Character.cs
@@ -53,7 +53,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The character's guild.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Guild"/>.
-        /// If the character is not representing a guild, this value is <c>null</c>.
+        /// If the character is not representing a guild, this value is <see langword="null"/>.
         /// </summary>
         public Guid? Guild { get; set; }
 
@@ -97,63 +97,63 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The character's WvW abilities.
         /// Additionally requires scopes: progression.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<CharacterWvwAbility>? WvwAbilities { get; set; }
 
         /// <summary>
         /// The number of build tabs that this character has unlocked.
         /// Additionally requires scopes: builds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? BuildTabsUnlocked { get; set; }
 
         /// <summary>
         /// The current active build tab index. To be used as index in <see cref="BuildTabs"/>.
         /// Additionally requires scopes: builds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? ActiveBuildTab { get; set; }
 
         /// <summary>
         /// The list of character build tabs.
         /// Additionally requires scopes: builds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<CharacterBuildTabSlot>? BuildTabs { get; set; }
 
         /// <summary>
         /// The list of the character equipment.
         /// Additionally requires scopes: builds and/or inventories.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<CharacterEquipmentItem>? Equipment { get; set; }
 
         /// <summary>
         /// The number of equipment tabs that this character has unlocked.
         /// Additionally requires scopes: builds and/or inventories.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? EquipmentTabsUnlocked { get; set; }
 
         /// <summary>
         /// The current active equipment tab index. To be used as index in <see cref="EquipmentTabs"/>.
         /// Additionally requires scopes: builds and/or inventories.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? ActiveEquipmentTab { get; set; }
 
         /// <summary>
         /// The list of the character equipment tabs.
         /// Additionally requires scopes: builds and/or inventories.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<CharacterEquipmentTabSlot>? EquipmentTabs { get; set; }
 
         /// <summary>
         /// The list of learned recipes.
         /// Additionally requires scopes: inventories.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Recipes"/>.
         /// </summary>
         public IReadOnlyList<int>? Recipes { get; set; }
@@ -161,7 +161,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The character PvP equipment.
         /// Additionally requires scopes: builds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         [Obsolete("Deprecated since schema version 2021-04-06T21:00:00.000Z. Use EquipmentTabs[i].EquipmentPvp instead. This will be removed from Gw2Sharp starting from version 2.0.")]
         public CharacterEquipmentPvp? EquipmentPvp =>
@@ -172,14 +172,14 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The list of character trainings.
         /// Additionally requires scopes: builds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<CharacterTraining>? Training { get; set; }
 
         /// <summary>
         /// The list of the character inventory bags.
         /// Additionally requires scopes: inventories.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<CharacterInventoryBag>? Bags { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentItem.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentItem.cs
@@ -27,54 +27,54 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The list of equipment tab indices that this item is used in.
         /// Each element can be resolved against <see cref="ICharactersIdClient.EquipmentTabs"/>.
-        /// If the item is not part of an equipment tab, this value is <c>null</c>.
+        /// If the item is not part of an equipment tab, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int>? Tabs { get; set; } = Array.Empty<int>();
 
         /// <summary>
         /// The list of upgrades applied to the equipped item.
-        /// If the item does not have any upgrades, this value is <c>null</c>.
+        /// If the item does not have any upgrades, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public IReadOnlyList<int>? Upgrades { get; set; }
 
         /// <summary>
         /// The list of infusions applied to the equipped item.
-        /// If the item does not have any upgrades, this value is <c>null</c>.
+        /// If the item does not have any upgrades, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public IReadOnlyList<int>? Infusions { get; set; }
 
         /// <summary>
         /// The skin id.
-        /// If the item is not skinnable or has the original skin, this value is <c>null</c>.
+        /// If the item is not skinnable or has the original skin, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skins"/>.
         /// </summary>
         public int? Skin { get; set; }
 
         /// <summary>
         /// The selected stats for the equipped item.
-        /// If the item has no selectable item stats, this value is <c>null</c>.
+        /// If the item has no selectable item stats, this value is <see langword="null"/>.
         /// </summary>
         public EquipmentItemStats? Stats { get; set; }
 
         /// <summary>
         /// The current binding of the equipped item.
-        /// If the item is not bound, this value is <c>null</c>.
+        /// If the item is not bound, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<ItemBinding>? Binding { get; set; }
 
         /// <summary>
         /// The name of the character to which the equipped item is bound.
-        /// If the item is not character bound (see <see cref="Binding"/>), this value is <c>null</c>.
+        /// If the item is not character bound (see <see cref="Binding"/>), this value is <see langword="null"/>.
         /// </summary>
         public string? BoundTo { get; set; }
 
         /// <summary>
         /// The selected dyes for the equipped item.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Colors"/>.
-        /// If the item does not support dyeing, this value is <c>null</c>.
-        /// If no dye is chosen for an element in this list, the element is <c>null</c>.
+        /// If the item does not support dyeing, this value is <see langword="null"/>.
+        /// If no dye is chosen for an element in this list, the element is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int?>? Dyes { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentPvp.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentPvp.cs
@@ -11,21 +11,21 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The PvP amulet.
-        /// If no amulet is selected, this value is <c>null</c>.
+        /// If no amulet is selected, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IPvpClient.Amulets"/>.
         /// </summary>
         public int? Amulet { get; set; }
 
         /// <summary>
         /// The PvP rune.
-        /// If no rune is selected, this value is <c>null</c>.
+        /// If no rune is selected, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public int? Rune { get; set; }
 
         /// <summary>
         /// The list of PvP sigils.
-        /// If a sigil is not selected in a specific slot, that value is <c>null</c>.
+        /// If a sigil is not selected in a specific slot, that value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
         /// </summary>
         public IReadOnlyList<int?> Sigils { get; set; } = Array.Empty<int?>();

--- a/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentTabSlot.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentTabSlot.cs
@@ -34,7 +34,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The PvP equipment.
         /// Additionally requires scopes: builds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public CharacterEquipmentPvp? EquipmentPvp { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Characters/CharacterInventoryBag.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/CharacterInventoryBag.cs
@@ -20,7 +20,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The bag inventory with a list of items.
-        /// If a slot is empty, that element is <c>null</c>.
+        /// If a slot is empty, that element is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<AccountItem?> Inventory { get; set; } = Array.Empty<AccountItem?>();
     }

--- a/Gw2Sharp/WebApi/V2/Models/Characters/CharacterSpecializations.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/CharacterSpecializations.cs
@@ -9,19 +9,19 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The list of PvE character specializations.
-        /// If a specialization is not selected in a specific slot, that value is <c>null</c>.
+        /// If a specialization is not selected in a specific slot, that value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<BuildTemplateSpecialization>? Pve { get; set; }
 
         /// <summary>
         /// The list of PvP character specializations.
-        /// If a specialization is not selected in a specific slot, that value is <c>null</c>.
+        /// If a specialization is not selected in a specific slot, that value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<BuildTemplateSpecialization>? Pvp { get; set; }
 
         /// <summary>
         /// The list of WvW character specializations.
-        /// If a specialization is not selected in a specific slot, that value is <c>null</c>.
+        /// If a specialization is not selected in a specific slot, that value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<BuildTemplateSpecialization>? Wvw { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Continents/ContinentFloorRegionMapPoi.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Continents/ContinentFloorRegionMapPoi.cs
@@ -14,7 +14,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The point of interest name.
-        /// If it has no name, this value is <c>null</c>.
+        /// If it has no name, this value is <see langword="null"/>.
         /// </summary>
         public string? Name { get; set; }
 
@@ -40,7 +40,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The point of interest icon.
-        /// If the point of interest has no icon, this value is <c>null</c>.
+        /// If the point of interest has no icon, this value is <see langword="null"/>.
         /// </summary>
         public RenderUrl? Icon { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Guild/Guild.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Guild/Guild.cs
@@ -10,56 +10,56 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The guild level.
         /// Additionally requires scopes: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? Level { get; set; }
 
         /// <summary>
         /// The guild message of the day.
         /// Additionally requires scopes: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public string? Motd { get; set; }
 
         /// <summary>
         /// The amount of influence.
         /// Additionally requires scopes: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? Influence { get; set; }
 
         /// <summary>
         /// The amount of aetherium.
         /// Additionally requires scopes: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? Aetherium { get; set; }
 
         /// <summary>
         /// The amount of resonance.
         /// Additionally requires scopes: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? Resonance { get; set; }
 
         /// <summary>
         /// The amount of favor.
         /// Additionally requires scopes: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? Favor { get; set; }
 
         /// <summary>
         /// The member count.
         /// Additionally requires scopes: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? MemberCount { get; set; }
 
         /// <summary>
         /// The member capacity.
         /// Additionally requires scoeps: guilds.
-        /// If the required scopes are not met, this value is <c>null</c>.
+        /// If the required scopes are not met, this value is <see langword="null"/>.
         /// </summary>
         public int? MemberCapacity { get; set; }
 
@@ -84,7 +84,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The guild emblem.
         /// No authentication required.
-        /// If the guild does not have an emblem, this value is <c>null</c>.
+        /// If the guild does not have an emblem, this value is <see langword="null"/>.
         /// </summary>
         public GuildEmblem? Emblem { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Guild/GuildLog.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Guild/GuildLog.cs
@@ -44,7 +44,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The guild log originating user.
-        /// If no user is associated with this log, this value is <c>null</c>.
+        /// If no user is associated with this log, this value is <see langword="null"/>.
         /// </summary>
         public string? User { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Guild/GuildLogUpgrade.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Guild/GuildLogUpgrade.cs
@@ -21,20 +21,20 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The item id.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Items"/>.
-        /// If no item is associated with this upgrade, this value is <c>null</c>.
+        /// If no item is associated with this upgrade, this value is <see langword="null"/>.
         /// </summary>
         public int? ItemId { get; set; }
 
         /// <summary>
         /// The recipe id.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Recipes"/>.
-        /// If no recipe is associated with this upgrade, this value is <c>null</c>.
+        /// If no recipe is associated with this upgrade, this value is <see langword="null"/>.
         /// </summary>
         public int? RecipeId { get; set; }
 
         /// <summary>
         /// The amount of items.
-        /// If no item is associated with this upgrade, this value is <c>null</c>.
+        /// If no item is associated with this upgrade, this value is <see langword="null"/>.
         /// </summary>
         public int? Count { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Guild/GuildMember.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Guild/GuildMember.cs
@@ -19,7 +19,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The time the guild member joined.
-        /// If the member joined before this was tracked, this value is <c>null</c>.
+        /// If the member joined before this was tracked, this value is <see langword="null"/>.
         /// </summary>
         public DateTimeOffset? Joined { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Guild/GuildTeam.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Guild/GuildTeam.cs
@@ -45,7 +45,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The team seasons.
-        /// If no seasons are available, this value is <c>null</c>.
+        /// If no seasons are available, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<GuildTeamSeason> Seasons { get; set; } = Array.Empty<GuildTeamSeason>();
     }

--- a/Gw2Sharp/WebApi/V2/Models/ItemAttributes.cs
+++ b/Gw2Sharp/WebApi/V2/Models/ItemAttributes.cs
@@ -9,63 +9,63 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The power attribute.
-        /// If the item has no power attribute, this value is <c>null</c>.
+        /// If the item has no power attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("Power")]
         public int? Power { get; set; }
 
         /// <summary>
         /// The precision attribute.
-        /// If the item has no precision attribute, this value is <c>null</c>.
+        /// If the item has no precision attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("Precision")]
         public int? Precision { get; set; }
 
         /// <summary>
         /// The ferocity attribute.
-        /// If the item has no ferocity attribute, this value is <c>null</c>.
+        /// If the item has no ferocity attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("CritDamage")]
         public int? CritDamage { get; set; }
 
         /// <summary>
         /// The toughness attribute.
-        /// If the item has no toughness attribute, this value is <c>null</c>.
+        /// If the item has no toughness attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("Toughness")]
         public int? Toughness { get; set; }
 
         /// <summary>
         /// The virtality attribute.
-        /// If the item has no virtality attribute, this value is <c>null</c>.
+        /// If the item has no virtality attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("Vitality")]
         public int? Vitality { get; set; }
 
         /// <summary>
         /// The condition damage attribute.
-        /// If the item has no condition damage attribute, this value is <c>null</c>.
+        /// If the item has no condition damage attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("ConditionDamage")]
         public int? ConditionDamage { get; set; }
 
         /// <summary>
         /// The condition duration attribute.
-        /// If the item has no condition duration attribute, this value is <c>null</c>.
+        /// If the item has no condition duration attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("ConditionDuration")]
         public int? ConditionDuration { get; set; }
 
         /// <summary>
         /// The healing attribute.
-        /// If the item has no healing attribute, this value is <c>null</c>.
+        /// If the item has no healing attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("Healing")]
         public int? Healing { get; set; }
 
         /// <summary>
         /// The boon duration attribute.
-        /// If the item has no boon duration attribute, this value is <c>null</c>.
+        /// If the item has no boon duration attribute, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("BoonDuration")]
         public int? BoonDuration { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/Items/Item.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/Item.cs
@@ -44,7 +44,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The item description.
-        /// If the item does not have a description, this value is <c>null</c>.
+        /// If the item does not have a description, this value is <see langword="null"/>.
         /// </summary>
         public string? Description { get; set; }
 
@@ -71,7 +71,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The item default skin.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skins"/>.
-        /// If the item does not have a default skin, this value is <c>null</c>.
+        /// If the item does not have a default skin, this value is <see langword="null"/>.
         /// </summary>
         public int? DefaultSkin { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemArmorDetails.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemArmorDetails.cs
@@ -35,19 +35,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The item infix upgrade.
-        /// If the item does not have a infix upgrade, this value is <c>null</c>.
+        /// If the item does not have a infix upgrade, this value is <see langword="null"/>.
         /// </summary>
         public ItemInfixUpgrade? InfixUpgrade { get; set; }
 
         /// <summary>
         /// The id of the suffix item.
-        /// If the item does not have a suffix item, this value is <c>null</c>.
+        /// If the item does not have a suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SuffixItemId { get; set; }
 
         /// <summary>
         /// The id of the secondary suffix item.
-        /// If the item does not have a secondary suffix item, this value is <c>null</c>.
+        /// If the item does not have a secondary suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SecondarySuffixItemId { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemBackDetails.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemBackDetails.cs
@@ -20,19 +20,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The item infix upgrade.
-        /// If the item does not have a infix upgrade, this value is <c>null</c>.
+        /// If the item does not have a infix upgrade, this value is <see langword="null"/>.
         /// </summary>
         public ItemInfixUpgrade? InfixUpgrade { get; set; }
 
         /// <summary>
         /// The id of the suffix item.
-        /// If the item does not have a suffix item, this value is <c>null</c>.
+        /// If the item does not have a suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SuffixItemId { get; set; }
 
         /// <summary>
         /// The id of the secondary suffix item.
-        /// If the item does not have a secondary suffix item, this value is <c>null</c>.
+        /// If the item does not have a secondary suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SecondarySuffixItemId { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemConsumableDetails.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemConsumableDetails.cs
@@ -20,52 +20,52 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The item duration in milliseconds.
-        /// If the item does not have a duration, this value is <c>null</c>.
+        /// If the item does not have a duration, this value is <see langword="null"/>.
         /// </summary>
         public int? DurationMs { get; set; }
 
         /// <summary>
         /// The item unlock type for unlock consumables, check <see cref="Type"/>.
-        /// If the item is not an unlock consumable, this value is <c>null</c>.
+        /// If the item is not an unlock consumable, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<ItemUnlockType>? UnlockType { get; set; }
 
         /// <summary>
         /// The dye id for dye unlocks, check <see cref="UnlockType"/>.
-        /// If the item is not a dye unlock, this value is <c>null</c>.
+        /// If the item is not a dye unlock, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Colors"/>.
         /// </summary>
         public int? ColorId { get; set; }
 
         /// <summary>
         /// The recipe id for recipe unlocks, check <see cref="UnlockType"/>.
-        /// If the item is not a recipe unlock, this value is <c>null</c>.
+        /// If the item is not a recipe unlock, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Recipes"/>.
         /// </summary>
         public int? RecipeId { get; set; }
 
         /// <summary>
         /// The guild upgrade id for generic unlocks, check <see cref="UnlockType"/>.
-        /// If the item is not a generic unlock nor a guild upgrade item, this value is <c>null</c>.
+        /// If the item is not a generic unlock nor a guild upgrade item, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGuildClient.Upgrades"/>.
         /// </summary>
         public int? GuildUpgradeId { get; set; }
 
         /// <summary>
         /// The number of stacks of the effect is applied by the item.
-        /// If the item does not apply an effect, this value is <c>null</c>.
+        /// If the item does not apply an effect, this value is <see langword="null"/>.
         /// </summary>
         public int? ApplyCount { get; set; }
 
         /// <summary>
         /// The effect tyype name of the item.
-        /// If the item does not apply an effect, this value is <c>null</c>.
+        /// If the item does not apply an effect, this value is <see langword="null"/>.
         /// </summary>
         public string? Name { get; set; }
 
         /// <summary>
         /// The list of skin ids which the item unlocks.
-        /// If the item does not unlock skins, this value is <c>null</c>.
+        /// If the item does not unlock skins, this value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Skins"/>.
         /// </summary>
         public IReadOnlyList<int>? Skins { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemInfixUpgrade.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemInfixUpgrade.cs
@@ -11,7 +11,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The infix upgrade item id.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Itemstats"/>.
-        /// If the infix upgrade does not have an item, this value is <c>null</c>.
+        /// If the infix upgrade does not have an item, this value is <see langword="null"/>.
         /// </summary>
         public int? Id { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemInfusionSlot.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemInfusionSlot.cs
@@ -12,7 +12,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The infusion item id.
-        /// If the item has no infusions, this value is <c>null</c>.
+        /// If the item has no infusions, this value is <see langword="null"/>.
         /// </summary>
         public int? ItemId { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemTrinketDetails.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemTrinketDetails.cs
@@ -25,19 +25,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The item infix upgrade.
-        /// If the item does not have a infix upgrade, this value is <c>null</c>.
+        /// If the item does not have a infix upgrade, this value is <see langword="null"/>.
         /// </summary>
         public ItemInfixUpgrade? InfixUpgrade { get; set; }
 
         /// <summary>
         /// The id of the suffix item.
-        /// If the item does not have a suffix item, this value is <c>null</c>.
+        /// If the item does not have a suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SuffixItemId { get; set; }
 
         /// <summary>
         /// The id of the secondary suffix item.
-        /// If the item does not have a secondary suffix item, this value is <c>null</c>.
+        /// If the item does not have a secondary suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SecondarySuffixItemId { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemUpgradeComponentDetails.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemUpgradeComponentDetails.cs
@@ -34,13 +34,13 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The item infix upgrade.
-        /// If the item does not have a infix upgrade, this value is <c>null</c>.
+        /// If the item does not have a infix upgrade, this value is <see langword="null"/>.
         /// </summary>
         public ItemInfixUpgrade? InfixUpgrade { get; set; }
 
         /// <summary>
         /// The item bonuses in case the item is a rune, check <see cref="Type"/>.
-        /// If the item is not a rune, this value is <c>null</c>.
+        /// If the item is not a rune, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<string>? Bonuses { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Items/ItemWeaponDetails.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Items/ItemWeaponDetails.cs
@@ -45,19 +45,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The item infix upgrade.
-        /// If the item does not have a infix upgrade, this value is <c>null</c>.
+        /// If the item does not have a infix upgrade, this value is <see langword="null"/>.
         /// </summary>
         public ItemInfixUpgrade? InfixUpgrade { get; set; }
 
         /// <summary>
         /// The id of the suffix item.
-        /// If the item does not have a suffix item, this value is <c>null</c>.
+        /// If the item does not have a suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SuffixItemId { get; set; }
 
         /// <summary>
         /// The id of the secondary suffix item.
-        /// If the item does not have a secondary suffix item, this value is <c>null</c>.
+        /// If the item does not have a secondary suffix item, this value is <see langword="null"/>.
         /// </summary>
         public int? SecondarySuffixItemId { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionSkill.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionSkill.cs
@@ -23,7 +23,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The required source profession id.
-        /// This value is <c>null</c> if the profession skill doesn't require a specific profession.
+        /// This value is <see langword="null"/> if the profession skill doesn't require a specific profession.
         /// </summary>
         public string Source { get; set; } = string.Empty;
     }

--- a/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionWeapon.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionWeapon.cs
@@ -10,7 +10,7 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The specialization that unlocks this weapon for the profession.
-        /// If no specialization is required, this value is <c>null</c>.
+        /// If no specialization is required, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Specializations"/>.
         /// </summary>
         public int Specialization { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionWeaponSkill.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Professions/ProfessionWeaponSkill.cs
@@ -18,7 +18,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The required off-hand weapon id.
-        /// This value is <c>null</c> if the skill doesn't require an off-hand weapon.
+        /// This value is <see langword="null"/> if the skill doesn't require an off-hand weapon.
         /// </summary>
         public string Offhand { get; set; } = string.Empty;
     }

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardSettings.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardSettings.cs
@@ -15,7 +15,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The leaderboard duration.
-        /// This value is <c>null</c> if it's unavailable.
+        /// This value is <see langword="null"/> if it's unavailable.
         /// </summary>
         public int? Duration { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardSettingsTier.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpSeasonLeaderboardSettingsTier.cs
@@ -7,19 +7,19 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The leaderboard tier color.
-        /// If the leadertier doesn't have a color, this value is <c>null</c>.
+        /// If the leadertier doesn't have a color, this value is <see langword="null"/>.
         /// </summary>
         public string? Color { get; set; }
 
         /// <summary>
         /// The leaderboard tier type.
-        /// If the leadertier doesn't have a type, this value is <c>null</c>.
+        /// If the leadertier doesn't have a type, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<PvpSeasonLeaderboardSettingsTierType>? Type { get; set; }
 
         /// <summary>
         /// The leaderboard tier name.
-        /// If the leadertier doesn't have a name, this value is <c>null</c>.
+        /// If the leadertier doesn't have a name, this value is <see langword="null"/>.
         /// </summary>
         public string? Name { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Pvp/PvpStandingRecord.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Pvp/PvpStandingRecord.cs
@@ -32,7 +32,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The PvP standing rating.
-        /// This value is <c>null</c> when the record doesn't track the rating.
+        /// This value is <see langword="null"/> when the record doesn't track the rating.
         /// </summary>
         public int? Rating { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Recipes/Recipe.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Recipes/Recipe.cs
@@ -62,14 +62,14 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The recipe ingredients from the guild.
-        /// If the recipe doesn't require any guild ingredients, this value is <c>null</c>.
+        /// If the recipe doesn't require any guild ingredients, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<RecipeGuildIngredient>? GuildIngredients { get; set; }
 
         /// <summary>
         /// The output guild upgrade id.
         /// Can be resolved against <see cref="IGuildClient.Upgrades"/>.
-        /// If the recipe doesn't output any guild upgrade, this value is <c>null</c>.
+        /// If the recipe doesn't output any guild upgrade, this value is <see langword="null"/>.
         /// </summary>
         public int OutputUpgradeId { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Skills/Skill.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/Skill.cs
@@ -32,7 +32,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The skill specialization.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Specializations"/>.
-        /// If the skill is not associated with a specific specialization, this value is <c>null</c>.
+        /// If the skill is not associated with a specific specialization, this value is <see langword="null"/>.
         /// </summary>
         public int? Specialization { get; set; }
 
@@ -43,13 +43,13 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The skill type.
-        /// If the skill does not have a type, this value is <c>null</c>.
+        /// If the skill does not have a type, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<SkillType>? Type { get; set; }
 
         /// <summary>
         /// The weapon type.
-        /// If the skill does not have a weapon type, this value is <c>null</c>.
+        /// If the skill does not have a weapon type, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<SkillWeaponType>? WeaponType { get; set; }
 
@@ -61,13 +61,13 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The skill slot.
-        /// If the skill does not have a slot, this value is <c>null</c>.
+        /// If the skill does not have a slot, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<SkillSlot>? Slot { get; set; }
 
         /// <summary>
         /// The dual attunement.
-        /// If the skill does not have a dual attunement, this value is <c>null</c>.
+        /// If the skill does not have a dual attunement, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<Attunement>? DualAttunement { get; set; }
 
@@ -78,92 +78,92 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The list of skill facts.
-        /// If the skill doesn't have any facts, this value is <c>null</c>.
+        /// If the skill doesn't have any facts, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<SkillFact>? Facts { get; set; }
 
         /// <summary>
         /// The list of traited skill facts.
-        /// If the skill doesn't have any traited facts, this value is <c>null</c>.
+        /// If the skill doesn't have any traited facts, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<SkillFact>? TraitedFacts { get; set; }
 
         /// <summary>
         /// The list of skill categories.
-        /// If the skill doesn't have any categories, this value is <c>null</c>.
+        /// If the skill doesn't have any categories, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<string>? Categories { get; set; }
 
         /// <summary>
         /// The list of sub skills.
-        /// If the skill doesn't have any sub skills, this value is <c>null</c>.
+        /// If the skill doesn't have any sub skills, this value is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("subskills")]
         public IReadOnlyList<SkillSubSkill>? SubSkills { get; set; }
 
         /// <summary>
         /// The attunement for elementalist weapon skills.
-        /// If the skill isn't an elementalist weapon skill, this value is <c>null</c>.
+        /// If the skill isn't an elementalist weapon skill, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<Attunement>? Attunement { get; set; }
 
         /// <summary>
         /// The skill cost, for e.g. revenant, warrior and druid skills.
-        /// If the skill doesn't have any cost, this value is <c>null</c>.
+        /// If the skill doesn't have any cost, this value is <see langword="null"/>.
         /// </summary>
         public int? Cost { get; set; }
 
         /// <summary>
         /// The dual wield weapon that needs to be equipped for this dual-wield skill to appear.
-        /// If the skill is not part of a dual-wield weapon, this value is <c>null</c>.
+        /// If the skill is not part of a dual-wield weapon, this value is <see langword="null"/>.
         /// </summary>
         public string? DualWield { get; set; }
 
         /// <summary>
         /// The skill id that this skill can flip to.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
-        /// If the skill does not have a flip skill, this value is <c>null</c>.
+        /// If the skill does not have a flip skill, this value is <see langword="null"/>.
         /// </summary>
         public int? FlipSkill { get; set; }
 
         /// <summary>
         /// The skill initiative cost for thief skills.
-        /// If the skill is not a thief skill, this value is <c>null</c>.
+        /// If the skill is not a thief skill, this value is <see langword="null"/>.
         /// </summary>
         public int? Initiative { get; set; }
 
         /// <summary>
         /// The next skill in the skill chain.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
-        /// If the skill does not have a next skill in the chain, or if the skill is not part of a skill chain at all, this value is <c>null</c>.
+        /// If the skill does not have a next skill in the chain, or if the skill is not part of a skill chain at all, this value is <see langword="null"/>.
         /// </summary>
         public int? NextChain { get; set; }
 
         /// <summary>
         /// The previous skill in the skill chain.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
-        /// If the skill does not have a previous skill in the chain, or if the skill is not part of a skill chain at all, this value is <c>null</c>.
+        /// If the skill does not have a previous skill in the chain, or if the skill is not part of a skill chain at all, this value is <see langword="null"/>.
         /// </summary>
         public int? PrevChain { get; set; }
 
         /// <summary>
         /// The transform skills that will replace the player's skills when the skill is activated.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
-        /// If the skill is not a transform skill, this value is <c>null</c>.
+        /// If the skill is not a transform skill, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int>? TransformSkills { get; set; }
 
         /// <summary>
         /// The bundle skills that will replace the player's skills when the skill is activated.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
-        /// If the skill is not a bundle skill, this value is <c>null</c>.
+        /// If the skill is not a bundle skill, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<int>? BundleSkills { get; set; }
 
         /// <summary>
         /// The associated toolbelt skill.
         /// Can be resolved against <see cref="IGw2WebApiV2Client.Skills"/>.
-        /// If the skill is not a toolbelt skill, this value is <c>null</c>.
+        /// If the skill is not a toolbelt skill, this value is <see langword="null"/>.
         /// </summary>
         public int? ToolbeltSkill { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Skills/SkillFact.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/SkillFact.cs
@@ -31,7 +31,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The skill fact icon URL.
-        /// If the skill fact doesn't have an icon, this value is <c>null</c>.
+        /// If the skill fact doesn't have an icon, this value is <see langword="null"/>.
         /// </summary>
         public RenderUrl? Icon { get; set; }
 
@@ -43,14 +43,14 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// Only used in <see cref="Skill.TraitedFacts"/>.
         /// The trait that's required for this skill fact to be used.
-        /// If the skill fact isn't a traited skill fact, this value is <c>null</c>.
+        /// If the skill fact isn't a traited skill fact, this value is <see langword="null"/>.
         /// </summary>
         public int? RequiresTrait { get; set; }
 
         /// <summary>
         /// Only used in <see cref="Skill.TraitedFacts"/>.
         /// The index of <see cref="Skill.Facts"/> that this skill fact overrides when active.
-        /// If the skill fact isn't a traited skill fact, or if the traited skill fact doesn't override an existing skill fact, this value is <c>null</c>.
+        /// If the skill fact isn't a traited skill fact, or if the traited skill fact doesn't override an existing skill fact, this value is <see langword="null"/>.
         /// </summary>
         public int? Overrides { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Skills/SkillFactBuff.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/SkillFactBuff.cs
@@ -12,19 +12,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The skill fact description.
-        /// If the skill fact doesn't have a description, this value is <c>null</c>.
+        /// If the skill fact doesn't have a description, this value is <see langword="null"/>.
         /// </summary>
         public string? Description { get; set; }
 
         /// <summary>
         /// The number of stacks applied.
-        /// If the skill fact doesn't apply stacks, this value is <c>null</c>.
+        /// If the skill fact doesn't apply stacks, this value is <see langword="null"/>.
         /// </summary>
         public int? ApplyCount { get; set; }
 
         /// <summary>
         /// The duration of the effect in seconds.
-        /// If the skill fact doesn't have a duration, this value is <c>null</c>.
+        /// If the skill fact doesn't have a duration, this value is <see langword="null"/>.
         /// </summary>
         public int? Duration { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Skills/SkillFactPercent.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/SkillFactPercent.cs
@@ -12,7 +12,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The skill fact value.
-        /// If the skill fact doesn't have a value, this value is <c>null</c>.
+        /// If the skill fact doesn't have a value, this value is <see langword="null"/>.
         /// </summary>
         public double? Value { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Skills/SkillFactPrefixedBuff.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/SkillFactPrefixedBuff.cs
@@ -12,19 +12,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The skill fact description.
-        /// If the skill fact doesn't have a description, this value is <c>null</c>.
+        /// If the skill fact doesn't have a description, this value is <see langword="null"/>.
         /// </summary>
         public string? Description { get; set; }
 
         /// <summary>
         /// The number of stacks applied.
-        /// If the skill fact doesn't apply stacks, this value is <c>null</c>.
+        /// If the skill fact doesn't apply stacks, this value is <see langword="null"/>.
         /// </summary>
         public int? ApplyCount { get; set; }
 
         /// <summary>
         /// The duration of the effect in seconds.
-        /// If the skill fact doesn't have a duration, this value is <c>null</c>.
+        /// If the skill fact doesn't have a duration, this value is <see langword="null"/>.
         /// </summary>
         public int? Duration { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Skills/SkillSubSkill.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/SkillSubSkill.cs
@@ -13,13 +13,13 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The sub skill attunement.
-        /// If the sub skill doesn't have an attunement, this value is <c>null</c>.
+        /// If the sub skill doesn't have an attunement, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<Attunement>? Attunement { get; set; }
 
         /// <summary>
         /// The sub skill form.
-        /// If the sub skill doesn't have a form, this value is <c>null</c>.
+        /// If the sub skill doesn't have a form, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<TransformationForm>? Form { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Skins/SkinArmorDetailsDyeSlots.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skins/SkinArmorDetailsDyeSlots.cs
@@ -10,7 +10,7 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The default dye slots.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<SkinDyeSlot?> Default { get; set; } = Array.Empty<SkinDyeSlot?>();
 

--- a/Gw2Sharp/WebApi/V2/Models/Skins/SkinArmorDetailsDyeSlotsOverrides.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skins/SkinArmorDetailsDyeSlotsOverrides.cs
@@ -10,80 +10,80 @@ namespace Gw2Sharp.WebApi.V2.Models
     {
         /// <summary>
         /// The overridden dye slots for male asura.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("AsuraMale")]
         public IReadOnlyList<SkinDyeSlot?>? AsuraMale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for female asura.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("AsuraFemale")]
         public IReadOnlyList<SkinDyeSlot?>? AsuraFemale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for male charr.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("CharrMale")]
         public IReadOnlyList<SkinDyeSlot?>? CharrMale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for female charr.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("CharrFemale")]
         public IReadOnlyList<SkinDyeSlot?>? CharrFemale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for male humans.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("HumanMale")]
         public IReadOnlyList<SkinDyeSlot?>? HumanMale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for female humans.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("HumanFemale")]
         public IReadOnlyList<SkinDyeSlot?>? HumanFemale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for male norn.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("NornMale")]
         public IReadOnlyList<SkinDyeSlot?>? NornMale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for female norn.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("NornFemale")]
         public IReadOnlyList<SkinDyeSlot?>? NornFemale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for male sylvari.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("SylvariMale")]
         public IReadOnlyList<SkinDyeSlot?>? SylvariMale { get; set; }
 
         /// <summary>
         /// The overridden dye slots for female sylvari.
-        /// If no overrides have been defined, this value is <c>null</c>.
-        /// If a dye slot isn't available, that element is <c>null</c>.
+        /// If no overrides have been defined, this value is <see langword="null"/>.
+        /// If a dye slot isn't available, that element is <see langword="null"/>.
         /// </summary>
         [JsonPropertyName("SylvariFemale")]
         public IReadOnlyList<SkinDyeSlot?>? SylvariFemale { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/Specializations/Specialization.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Specializations/Specialization.cs
@@ -45,7 +45,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The weapon trait associated with the specialization.
-        /// If the specialization does not have an associated weapon trait, this value is <c>null</c>.
+        /// If the specialization does not have an associated weapon trait, this value is <see langword="null"/>.
         /// Can be resolved against <see cref="ITraitsClient"/>.
         /// </summary>
         public int? WeaponTrait { get; set; }
@@ -62,13 +62,13 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The big specialization profession icon URL.
-        /// If the specialization does not have a profession icon, this value is <c>null</c>.
+        /// If the specialization does not have a profession icon, this value is <see langword="null"/>.
         /// </summary>
         public RenderUrl? ProfessionIconBig { get; set; }
 
         /// <summary>
         /// The specialization profession icon URL.
-        /// If the specialization does not have a profession icon, this value is <c>null</c>.
+        /// If the specialization does not have a profession icon, this value is <see langword="null"/>.
         /// </summary>
         public RenderUrl? ProfessionIcon { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Stories/Story.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Stories/Story.cs
@@ -42,7 +42,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The races that have access to this story.
-        /// If this story has no racial restriction, this value is <c>null</c>.
+        /// If this story has no racial restriction, this value is <see langword="null"/>.
         /// Each element can be resolved against <see cref="IGw2WebApiV2Client.Races"/>.
         /// </summary>
         public IReadOnlyList<string>? Races { get; set; }

--- a/Gw2Sharp/WebApi/V2/Models/Traits/Trait.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Traits/Trait.cs
@@ -45,25 +45,25 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The trait slot.
-        /// If the trait does not have a slot, this value is <c>null</c>.
+        /// If the trait does not have a slot, this value is <see langword="null"/>.
         /// </summary>
         public ApiEnum<TraitSlot>? Slot { get; set; }
 
         /// <summary>
         /// The list of trait facts.
-        /// If the trait doesn't have any facts, this value is <c>null</c>.
+        /// If the trait doesn't have any facts, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<TraitFact>? Facts { get; set; }
 
         /// <summary>
         /// The list of traited skill facts.
-        /// If the skill doesn't have any traited facts, this value is <c>null</c>.
+        /// If the skill doesn't have any traited facts, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<TraitFact>? TraitedFacts { get; set; }
 
         /// <summary>
         /// The list of trait skills.
-        /// If the trait doesn't have any skills, this value is <c>null</c>.
+        /// If the trait doesn't have any skills, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<TraitSkill>? Skills { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Traits/TraitFact.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Traits/TraitFact.cs
@@ -28,7 +28,7 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The trait fact icon URL.
-        /// If the trait fact doesn't have an icon, this value is <c>null</c>.
+        /// If the trait fact doesn't have an icon, this value is <see langword="null"/>.
         /// </summary>
         public RenderUrl? Icon { get; set; }
 
@@ -40,14 +40,14 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// Only used in <see cref="Trait.TraitedFacts"/>.
         /// The trait that's required for this trait fact to be used.
-        /// If the trait fact isn't a traited trait fact, this value is <c>null</c>.
+        /// If the trait fact isn't a traited trait fact, this value is <see langword="null"/>.
         /// </summary>
         public int? RequiresTrait { get; set; }
 
         /// <summary>
         /// Only used in <see cref="Trait.TraitedFacts"/>.
         /// The index of <see cref="Trait.Facts"/> that this trait fact overrides when active.
-        /// If the trait fact isn't a traited trait fact, or if the traited trait fact doesn't override an existing trait fact, this value is <c>null</c>.
+        /// If the trait fact isn't a traited trait fact, or if the traited trait fact doesn't override an existing trait fact, this value is <see langword="null"/>.
         /// </summary>
         public int? Overrides { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Traits/TraitFactBuff.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Traits/TraitFactBuff.cs
@@ -12,19 +12,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The trait fact description.
-        /// If the trait fact doesn't have a description, this value is <c>null</c>.
+        /// If the trait fact doesn't have a description, this value is <see langword="null"/>.
         /// </summary>
         public string? Description { get; set; }
 
         /// <summary>
         /// The number of stacks applied.
-        /// If the trait fact doesn't apply stacks, this value is <c>null</c>.
+        /// If the trait fact doesn't apply stacks, this value is <see langword="null"/>.
         /// </summary>
         public int? ApplyCount { get; set; }
 
         /// <summary>
         /// The duration of the effect in seconds.
-        /// If the trait fact doesn't have a duration, this value is <c>null</c>.
+        /// If the trait fact doesn't have a duration, this value is <see langword="null"/>.
         /// </summary>
         public int? Duration { get; set; }
     }

--- a/Gw2Sharp/WebApi/V2/Models/Traits/TraitFactPrefixedBuff.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Traits/TraitFactPrefixedBuff.cs
@@ -12,19 +12,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The trait fact description.
-        /// If the trait fact doesn't have a description, this value is <c>null</c>.
+        /// If the trait fact doesn't have a description, this value is <see langword="null"/>.
         /// </summary>
         public string? Description { get; set; }
 
         /// <summary>
         /// The number of stacks applied.
-        /// If the trait fact doesn't apply stacks, this value is <c>null</c>.
+        /// If the trait fact doesn't apply stacks, this value is <see langword="null"/>.
         /// </summary>
         public int? ApplyCount { get; set; }
 
         /// <summary>
         /// The duration of the effect in seconds.
-        /// If the trait fact doesn't have a duration, this value is <c>null</c>.
+        /// If the trait fact doesn't have a duration, this value is <see langword="null"/>.
         /// </summary>
         public int? Duration { get; set; }
 

--- a/Gw2Sharp/WebApi/V2/Models/Traits/TraitSkill.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Traits/TraitSkill.cs
@@ -41,19 +41,19 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The list of skill facts.
-        /// If the skill doesn't have any facts, this value is <c>null</c>.
+        /// If the skill doesn't have any facts, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<SkillFact>? Facts { get; set; } = Array.Empty<SkillFact>();
 
         /// <summary>
         /// The list of traited skill facts.
-        /// If the skill doesn't have any traited facts, this value is <c>null</c>.
+        /// If the skill doesn't have any traited facts, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<SkillFact>? TraitedFacts { get; set; } = Array.Empty<SkillFact>();
 
         /// <summary>
         /// The list of skill categories.
-        /// If the skill doesn't have any categories, this value is <c>null</c>.
+        /// If the skill doesn't have any categories, this value is <see langword="null"/>.
         /// </summary>
         public IReadOnlyList<string>? Categories { get; set; } = Array.Empty<string>();
     }

--- a/Gw2Sharp/WebApi/V2/Models/Wvw/WvwMatchMapObjective.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Wvw/WvwMatchMapObjective.cs
@@ -31,13 +31,13 @@ namespace Gw2Sharp.WebApi.V2.Models
 
         /// <summary>
         /// The id of the guild that has claimed the objective.
-        /// If no guild has claimed the objective, this value is <c>null</c>.
+        /// If no guild has claimed the objective, this value is <see langword="null"/>.
         /// </summary>
         public Guid? ClaimedBy { get; set; }
 
         /// <summary>
         /// The timestamp of when the objective has been claimed.
-        /// If no guild has claimed the objective, this value is <c>null</c>.
+        /// If no guild has claimed the objective, this value is <see langword="null"/>.
         /// </summary>
         public DateTime? ClaimedAt { get; set; }
 


### PR DESCRIPTION
`<c>...</c>` isn't the correct way to reference `null`, `true` or `false`. Instead, this should be `<see langword="..."/>`.