### PR TITLE
Implement configurable API and render base URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Gw2Sharp History
 
+## 1.6.0 (15 November 2021)
+This release includes a feature to change the API hostname(s) in case you want to run a proxy API server. See [the documentation](https://archomeda.github.io/Gw2Sharp/master/guides/proxy.html) for more information.
+
+### HTTP
+- Add `ApiBaseUrl` and `RenderBaseUrl` properties to `Gw2Sharp.IConnection` ([#108](https://github.com/Archomeda/Gw2Sharp/issues/108), [#107](https://github.com/Archomeda/Gw2Sharp/pull/109))
+
+---
+
 ## 1.5.0 (13 November 2021)
 This release contains one small addition to make changing the request timeout easier.
 

--- a/Gw2Sharp.Tests/Json/Converters/RenderUrlConverterTests.cs
+++ b/Gw2Sharp.Tests/Json/Converters/RenderUrlConverterTests.cs
@@ -11,10 +11,12 @@ namespace Gw2Sharp.Tests.Json.Converters
 {
     public class RenderUrlConverterTests
     {
+        private readonly IConnection connection;
         private readonly IGw2Client client;
 
         public RenderUrlConverterTests()
         {
+            this.connection = new Connection();
             this.client = Substitute.For<IGw2Client>();
             this.client.WebApi.Returns(Substitute.For<IGw2WebApiClient>());
             this.client.WebApi.Render.Returns(Substitute.For<IGw2WebApiRenderClient>());
@@ -23,14 +25,14 @@ namespace Gw2Sharp.Tests.Json.Converters
         [Fact]
         public void NoWriteTest()
         {
-            var converter = new RenderUrlConverter(this.client);
+            var converter = new RenderUrlConverter(this.connection, this.client);
             Assert.Throws<NotImplementedException>(() => converter.Write(default!, default!, default!));
         }
 
         [Fact]
         public void CanConvertTest()
         {
-            var converter = new RenderUrlConverter(this.client);
+            var converter = new RenderUrlConverter(this.connection, this.client);
             Assert.True(converter.CanConvert(typeof(RenderUrl)));
         }
 
@@ -40,7 +42,7 @@ namespace Gw2Sharp.Tests.Json.Converters
         {
             var actual = JsonSerializer.Deserialize<RenderUrl>(json, new JsonSerializerOptions
             {
-                Converters = { new RenderUrlConverter(this.client) }
+                Converters = { new RenderUrlConverter(this.connection, this.client) }
             });
 
             actual.Url.AbsoluteUri.Should().Be(expected);
@@ -56,7 +58,7 @@ namespace Gw2Sharp.Tests.Json.Converters
         {
             Action action = () => JsonSerializer.Deserialize<RenderUrl>(json, new JsonSerializerOptions
             {
-                Converters = { new RenderUrlConverter(this.client) }
+                Converters = { new RenderUrlConverter(this.connection, this.client) }
             });
             action.Should().Throw<JsonException>();
         }

--- a/Gw2Sharp.Tests/WebApi/Gw2WebApiClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/Gw2WebApiClientTests.cs
@@ -10,7 +10,7 @@ namespace Gw2Sharp.Tests.WebApi
         [Fact]
         public void ConstructorTest()
         {
-            var connection = Substitute.For<IConnection>();
+            var connection = new Connection();
             var gw2Client = Substitute.For<IGw2Client>();
 
             var client = new Gw2WebApiClient(connection, gw2Client);

--- a/Gw2Sharp.Tests/WebApi/RenderUrlTests.cs
+++ b/Gw2Sharp.Tests/WebApi/RenderUrlTests.cs
@@ -21,15 +21,16 @@ namespace Gw2Sharp.Tests.WebApi
             this.client.WebApi.Render.Returns(Substitute.For<IGw2WebApiRenderClient>());
         }
 
-        [Fact]
-        public void ConstructorTest()
+        [Theory]
+        [InlineData("https://render.guildwars2.com/file/test/1234.png", null, "https://render.guildwars2.com/file/test/1234.png")]
+        [InlineData("https://render.guildwars2.com/file/test/1234.png", "https://proxy.render.example.com/", "https://proxy.render.example.com/file/test/1234.png")]
+        public void ConstructorTest(string url, string? hostnameReplacement, string expected)
         {
-            string url = "https://render.guildwars2.com/file/test/1234.png";
-            var renderUrl = new RenderUrl(this.client, url);
+            var renderUrl = new RenderUrl(this.client, url, hostnameReplacement);
 
-            Assert.Equal(url, renderUrl.Url.ToString());
-            Assert.Equal(url, renderUrl.ToString());
-            Assert.Equal(url, renderUrl);
+            Assert.Equal(expected, renderUrl.Url.ToString());
+            Assert.Equal(expected, renderUrl.ToString());
+            Assert.Equal(expected, renderUrl);
             Assert.Equal(this.client, renderUrl.Gw2Client);
         }
 
@@ -43,7 +44,7 @@ namespace Gw2Sharp.Tests.WebApi
             this.client.WebApi.Render.DownloadToByteArrayAsync(Arg.Any<Uri>()).Returns(expected);
             this.client.WebApi.Render.DownloadToByteArrayAsync(Arg.Any<Uri>(), Arg.Any<CancellationToken>()).Returns(expected);
 
-            var renderUrl = new RenderUrl(this.client, url);
+            var renderUrl = new RenderUrl(this.client, url, null);
             byte[] actual = await renderUrl.DownloadToByteArrayAsync();
 
             Assert.Equal(expected, actual);
@@ -55,7 +56,7 @@ namespace Gw2Sharp.Tests.WebApi
             string url = "https://render.guildwars2.com/file/test/1234.png";
             using var memoryStream = new MemoryStream();
 
-            var renderUrl = new RenderUrl(this.client, url);
+            var renderUrl = new RenderUrl(this.client, url, null);
             await renderUrl.DownloadToStreamAsync(memoryStream);
 
             int notReceived = 0;

--- a/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
@@ -205,7 +205,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
         protected virtual void AssertRequest(CallInfo callInfo, IEndpointClient client, string pathAndQuery)
         {
             // Format the URI to how it's supposed to be
-            var uri = new Uri(Gw2WebApiV2Client.UrlBase, $"{client.EndpointPath}{pathAndQuery}");
+            var uri = new Uri(new Uri(client.BaseUrl), $"{client.EndpointPath}{pathAndQuery}");
             var parameterProperties = client.GetType()
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.GetCustomAttribute<EndpointQueryParameterAttribute>() != null);

--- a/Gw2Sharp/Connection.cs
+++ b/Gw2Sharp/Connection.cs
@@ -132,6 +132,12 @@ namespace Gw2Sharp
         public string UserAgent { get; }
 
         /// <inheritdoc />
+        public string ApiBaseUrl { get; set; } = "https://api.guildwars2.com/";
+
+        /// <inheritdoc />
+        public string? RenderBaseUrl { get; set; }
+
+        /// <inheritdoc />
         public TimeSpan RequestTimeout
         {
             get => this.HttpClient.Timeout;

--- a/Gw2Sharp/Connection.cs
+++ b/Gw2Sharp/Connection.cs
@@ -20,6 +20,7 @@ namespace Gw2Sharp
         private ICacheMethod cacheMethod;
         private ICacheMethod renderCacheMethod;
         private string accessToken;
+        private string apiBaseUrl = "https://api.guildwars2.com/";
         private readonly ObservableCollection<IWebApiMiddleware> middleware = new ObservableCollection<IWebApiMiddleware>();
 
 
@@ -132,7 +133,11 @@ namespace Gw2Sharp
         public string UserAgent { get; }
 
         /// <inheritdoc />
-        public string ApiBaseUrl { get; set; } = "https://api.guildwars2.com/";
+        public string ApiBaseUrl
+        {
+            get => this.apiBaseUrl;
+            set => this.apiBaseUrl = value ?? throw new ArgumentNullException(nameof(value), "ApiBaseUrl cannot be null");
+        }
 
         /// <inheritdoc />
         public string? RenderBaseUrl { get; set; }

--- a/Gw2Sharp/IConnection.cs
+++ b/Gw2Sharp/IConnection.cs
@@ -34,6 +34,17 @@ namespace Gw2Sharp
         string UserAgent { get; }
 
         /// <summary>
+        /// The API base URL that is used to construct the final URL for the API requests.
+        /// </summary>
+        string ApiBaseUrl { get; }
+
+        /// <summary>
+        /// The render base URL that is used to replace the render API hostname that are returned from the API.
+        /// If <see langword="null"/>, the hostname is not replaced.
+        /// </summary>
+        string? RenderBaseUrl { get; }
+
+        /// <summary>
         /// Gets the request timeout that's used for the API requests.
         /// If <see cref="TimeSpan.Zero"/> or less, the default timeout is used.
         /// This value can be <see cref="Timeout.InfiniteTimeSpan"/> to have no timeout.

--- a/Gw2Sharp/Json/Converters/RenderUrlConverter.cs
+++ b/Gw2Sharp/Json/Converters/RenderUrlConverter.cs
@@ -11,14 +11,17 @@ namespace Gw2Sharp.Json.Converters
     /// <seealso cref="JsonConverter{T}" />
     public sealed class RenderUrlConverter : JsonConverter<RenderUrl>
     {
+        private readonly IConnection connection;
         private readonly IGw2Client gw2Client;
 
         /// <summary>
         /// Creates a new <see cref="RenderUrlConverter"/>
         /// </summary>
+        /// <param name="connection">The connection used to make requests, see <see cref="IConnection"/>.</param>
         /// <param name="gw2Client">The Guild Wars 2 client.</param>
-        public RenderUrlConverter(IGw2Client gw2Client)
+        public RenderUrlConverter(IConnection connection, IGw2Client gw2Client)
         {
+            this.connection = connection;
             this.gw2Client = gw2Client;
         }
 
@@ -27,7 +30,7 @@ namespace Gw2Sharp.Json.Converters
         {
             if (reader.TokenType != JsonTokenType.String)
                 throw new JsonException("Expected a string value");
-            return new RenderUrl(this.gw2Client, reader.GetString()!);
+            return new RenderUrl(this.gw2Client, reader.GetString()!, this.connection.RenderBaseUrl);
         }
 
         /// <inheritdoc />

--- a/Gw2Sharp/WebApi/Gw2WebApiClient.cs
+++ b/Gw2Sharp/WebApi/Gw2WebApiClient.cs
@@ -9,11 +9,6 @@ namespace Gw2Sharp.WebApi
     /// </summary>
     public class Gw2WebApiClient : IGw2WebApiClient
     {
-        /// <summary>
-        /// The base URL for making Guild Wars 2 API requests.
-        /// </summary>
-        internal static Uri UrlBase => new Uri("https://api.guildwars2.com");
-
         private readonly IGw2WebApiRenderClient render;
         private readonly IGw2WebApiV2Client v2;
 

--- a/Gw2Sharp/WebApi/Http/WebApiRequest.cs
+++ b/Gw2Sharp/WebApi/Http/WebApiRequest.cs
@@ -29,7 +29,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <summary>
         /// The settings that are used when deserializing JSON objects.
         /// </summary>
-        private static JsonSerializerOptions GetDeserializerSettings(IGw2Client client)
+        private static JsonSerializerOptions GetDeserializerSettings(IConnection connection, IGw2Client client)
         {
             var options = new JsonSerializerOptions
             {
@@ -43,7 +43,7 @@ namespace Gw2Sharp.WebApi.Http
             options.Converters.Add(new ApiObjectListConverter());
             options.Converters.Add(new CastableTypeConverter());
             options.Converters.Add(new DictionaryIntKeyConverter());
-            options.Converters.Add(new RenderUrlConverter(client));
+            options.Converters.Add(new RenderUrlConverter(connection, client));
             options.Converters.Add(new TimeSpanConverter());
             return options;
         }
@@ -109,7 +109,7 @@ namespace Gw2Sharp.WebApi.Http
         /// <inheritdoc />
         public async Task<IWebApiResponse<TResponse>> ExecuteAsync<TResponse>(CancellationToken cancellationToken = default)
         {
-            var deserializerSettings = GetDeserializerSettings(this.gw2Client);
+            var deserializerSettings = GetDeserializerSettings(this.connection, this.gw2Client);
 
             var call = requestCalls.GetOrAdd(this.connection.MiddlewareHashCode, _ => this.GenerateRequestCall());
             var response = await call(new MiddlewareContext(this.connection, this), cancellationToken).ConfigureAwait(false);

--- a/Gw2Sharp/WebApi/RenderUrl.cs
+++ b/Gw2Sharp/WebApi/RenderUrl.cs
@@ -18,10 +18,12 @@ namespace Gw2Sharp.WebApi
         /// </summary>
         /// <param name="client">The Guild Wars 2 client.</param>
         /// <param name="url">The URL to a resource on the Guild Wars 2 render service API.</param>
-        internal RenderUrl(IGw2Client client, string url)
+        /// <param name="baseUrl">The base URL that is used instead of the hostname. If <see langword="null"/>, the hostname isn't replaced.</param>
+        internal RenderUrl(IGw2Client client, string url, string? baseUrl)
         {
             this.Gw2Client = client;
-            this.Url = new Uri(url);
+            var uri = new Uri(url);
+            this.Url = baseUrl is null ? uri : new Uri(new Uri(baseUrl), uri.PathAndQuery);
         }
 
 

--- a/Gw2Sharp/WebApi/V2/Clients/BaseEndpointClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/BaseEndpointClient.cs
@@ -31,7 +31,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
             if (gw2Client == null)
                 throw new ArgumentNullException(nameof(gw2Client));
 
-            this.BaseUrl = Gw2WebApiV2Client.UrlBase.AbsoluteUri;
+            this.BaseUrl = new Uri(new Uri(connection.ApiBaseUrl), Gw2WebApiV2Client.URL_PATH).ToString();
             this.EndpointPath = this.GetRequiredAttribute<EndpointPathAttribute>().EndpointPath;
             this.parameterProperties = this.GetType()
                 .GetProperties(BindingFlags.Public | BindingFlags.Instance)

--- a/Gw2Sharp/WebApi/V2/Gw2WebApiV2Client.cs
+++ b/Gw2Sharp/WebApi/V2/Gw2WebApiV2Client.cs
@@ -9,9 +9,9 @@ namespace Gw2Sharp.WebApi.V2
     public class Gw2WebApiV2Client : Gw2WebApiBaseClient, IGw2WebApiV2Client
     {
         /// <summary>
-        /// The base URL for making Guild Wars 2 API v2 requests.
+        /// The path that the v2 endpoints can be accessed.
         /// </summary>
-        internal static Uri UrlBase => new Uri(Gw2WebApiClient.UrlBase, "v2/");
+        internal const string URL_PATH = "v2/";
 
         private readonly IAccountClient account;
         private readonly IAchievementsClient achievements;

--- a/docs/guides/proxy.md
+++ b/docs/guides/proxy.md
@@ -1,0 +1,38 @@
+---
+uid: Guides.Proxy
+title: Proxying the API
+---
+
+# Proxying the API
+Starting with version 1.6.0, you can use a different base URL for the API calls.
+This means that instead of using `https://api.guildwars2.com/` as server, you can use any other base URL.
+The path to the endpoints stay the same, so your proxy server needs to match the official API server.
+
+Gw2Sharp also supports replacing the base URL for render API calls.
+The concept is the same, but because these URLs are returned from the API server and not constructed by Gw2Sharp, Gw2Sharp replaces all hostnames to `https://render.guildwars2.com/` with your base URL (this is visible in the [RenderUrl objects](xref:Guides.RenderUrl)).
+
+You can set these options in your `Connection` object:
+
+```cs
+var connection = new Gw2Sharp.Connection();
+
+// The following sets the API base URL, this defaults to https://api.guildwars2.com/.
+connection.ApiBaseUrl = "https://my.proxy.server.example.com/";
+
+// The following sets the render API base URL,
+// this defaults to null which means that no replacement will be done
+connection.RenderBaseUrl = "https://my.render.server.example.com/";
+```
+
+> [!WARNING]
+> Setting the `RenderBaseUrl` to anything else than `null`, will replace the render API hostname with that value. This includes an empty string!
+
+## Using a different API server region
+The Guild Wars 2 API server is hosted in both NA and EU region, but using `https://api.guildwars2.com/` will load balance you to the closest region you're sending the request from.
+You can override this by proxying to the other region's IP address explicitly.
+How to get those IP addresses is out-of-scope for this guide, but there's one thing you need to do extra in Gw2Sharp in order to support this.
+
+Basically, whenever an HTTP request is done, any sane client will automatically set the `Host` header to the domain you're requesting a page from.
+This also means that, when you set an IP address, this IP address is used for the `Host` header, and not `api.guildwars2.com`.
+So you'll have to override this behavior by writing a custom Gw2Sharp middleware that will set this header in the [`Gw2Sharp.WebApi.Middleware.IWebApiMiddleware.OnRequestAsync`](../api/Gw2Sharp.WebApi.Middleware.IWebApiMiddleware.html) method.
+The middleware context contains the `Request.Options.RequestHeaders` property where you can add a `Host` header.

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -16,6 +16,8 @@
       topicUid: Guides.LastModified
     - name: Middleware
       topicUid: Guides.Middleware
+    - name: Proxying the API
+      topicUid: Guides.Proxy
     - name: Subtokens
       topicUid: Guides.Subtokens
     - name: Debug symbols


### PR DESCRIPTION
This will make the API hostnames configurable through the Connection class. Both the API hostname and the render hostname can be swapped to a custom base URL one.

Closes #108 