### PR TITLE
Custom Mumble Link reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Gw2Sharp History
 
-## 1.6.0 (15 November 2021)
+## 1.6.0 (30 December 2021)
 This release includes support for a couple of additional customizations:
 - Ability to change the API hostname(s) in case you want to run a proxy API server (see [the documentation](https://archomeda.github.io/Gw2Sharp/master/guides/proxy.html) for more information)
 - Ability to change the Mumble Link reader for mocking, or to use a different method and/or source for Mumble Link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Gw2Sharp History
 
 ## 1.6.0 (15 November 2021)
-This release includes a feature to change the API hostname(s) in case you want to run a proxy API server. See [the documentation](https://archomeda.github.io/Gw2Sharp/master/guides/proxy.html) for more information.
+This release includes support for a couple of additional customizations:
+- Ability to change the API hostname(s) in case you want to run a proxy API server (see [the documentation](https://archomeda.github.io/Gw2Sharp/master/guides/proxy.html) for more information)
+- Ability to change the Mumble Link reader for mocking, or to use a different method and/or source for Mumble Link
 
 ### HTTP
-- Add `ApiBaseUrl` and `RenderBaseUrl` properties to `Gw2Sharp.IConnection` ([#108](https://github.com/Archomeda/Gw2Sharp/issues/108), [#107](https://github.com/Archomeda/Gw2Sharp/pull/109))
+- Add `ApiBaseUrl` and `RenderBaseUrl` properties to `Gw2Sharp.IConnection` ([#108](https://github.com/Archomeda/Gw2Sharp/issues/108), [#109](https://github.com/Archomeda/Gw2Sharp/pull/109))
+
+### Mumble Link
+- Add support for custom Mumble Link readers ([#110](https://github.com/Archomeda/Gw2Sharp/pull/110))
+  -  Add `MumbleClientReaderFactory` property to `Gw2Sharp.IConnection` that constructs a new Mumble Link reader that implements `Gw2Sharp.Mumble.IGw2MumbleClientReader`
+  - .NET 5 and up: `SupportedOSPlatformAttribute`s have been moved around to support these changes
+  - The following structs that are used in the reader have been made public: `Gw2Sharp.Mumble.Gw2LinkedMem`, `Gw2Sharp.Mumble.Gw2Context` and `Gw2Sharp.Mumble.Models.UiState`
 
 ---
 

--- a/Gw2Sharp.Tests/ConnectionTests.cs
+++ b/Gw2Sharp.Tests/ConnectionTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Diagnostics;
+using AutoFixture.Xunit2;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using Gw2Sharp.Mumble;
 using Gw2Sharp.WebApi;
 using Gw2Sharp.WebApi.Caching;
 using Gw2Sharp.WebApi.Http;
@@ -107,6 +109,23 @@ namespace Gw2Sharp.Tests
             // so we don't have to manually test every enum with custom string values in existence.
             var connection = new Connection(locale);
             Assert.Equal(expected, connection.LocaleString);
+        }
+
+        [Theory]
+        [AutoData]
+        public void UsesCorrectMumbleClientReaderFactoryTest(string mumbleLinkName)
+        {
+            var connection = new Connection();
+            using var actual = connection.MumbleClientReaderFactory(mumbleLinkName);
+
+#if NET5_0_OR_GREATER
+            if (OperatingSystem.IsWindows())
+#else
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+#endif
+                actual.Should().BeOfType<Gw2MumbleClientReader>();
+            else
+                actual.Should().BeOfType<UnsupportedMumblePlatformClientReader>();
         }
     }
 }

--- a/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
+++ b/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
     <LangVersion>preview</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>annotations</Nullable>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
     <IsTestProject>true</IsTestProject>

--- a/Gw2Sharp.Tests/Mumble/Gw2MumbleClientReaderTests.cs
+++ b/Gw2Sharp.Tests/Mumble/Gw2MumbleClientReaderTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.IO.MemoryMappedFiles;
+using System.Net.Sockets;
+using System.Reflection;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Gw2Sharp.Models;
+using Gw2Sharp.Mumble;
+using Gw2Sharp.Mumble.Models;
+using Xunit;
+
+namespace Gw2Sharp.Tests.Mumble
+{
+    public class Gw2MumbleClientReaderTests
+    {
+        private bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+        [Fact]
+        public void ThrowsPlatformNotSupportedExceptionIfNotWindowsTest()
+        {
+            Action createClient = () =>
+            {
+                using var reader = new Gw2MumbleClientReader();
+            };
+
+            if (this.isWindows)
+                createClient.Should().NotThrow<PlatformNotSupportedException>();
+            else
+                createClient.Should().Throw<PlatformNotSupportedException>();
+        }
+
+        [SkippableFact]
+        public unsafe void ReadStructCorrectlyTest()
+        {
+            // Named memory mapped files aren't supported on Unix based systems.
+            // So we need to skip this test.
+            Skip.IfNot(this.isWindows, "Mumble Link is only supported on Windows");
+
+            using var memorySource = Assembly.GetExecutingAssembly().GetManifestResourceStream($"Gw2Sharp.Tests.TestFiles.Mumble.MemoryMappedFile.bin");
+            using var memoryMappedFile = MemoryMappedFile.CreateOrOpen(Gw2MumbleClient.DEFAULT_MUMBLE_LINK_MAP_NAME, memorySource.Length);
+            using var stream = memoryMappedFile.CreateViewStream();
+            memorySource.CopyTo(stream);
+
+            using var client = new Gw2MumbleClientReader();
+            client.Open(Gw2MumbleClient.DEFAULT_MUMBLE_LINK_MAP_NAME);
+            var mem = client.Read();
+
+            using (new AssertionScope())
+            {
+                mem.uiVersion.Should().Be(2);
+                mem.uiTick.Should().Be(7244);
+                mem.fAvatarPosition[0].Should().BeApproximately(-68.27287f, 5);
+                mem.fAvatarPosition[1].Should().BeApproximately(119.209f, 3);
+                mem.fAvatarPosition[2].Should().BeApproximately(-6.154798f, 6);
+                mem.fAvatarFront[0].Should().BeApproximately(0.8834972f, 7);
+                mem.fAvatarFront[1].Should().BeApproximately(0f, 5);
+                mem.fAvatarFront[2].Should().BeApproximately(-0.4684365f, 7);
+                new string(mem.name).Should().BeEquivalentTo(Gw2MumbleClient.MUMBLE_LINK_GAME_NAME_GUILD_WARS_2);
+                mem.fCameraPosition[0].Should().BeApproximately(-78.08988f, 5);
+                mem.fCameraPosition[1].Should().BeApproximately(126.4892f, 4);
+                mem.fCameraPosition[2].Should().BeApproximately(-0.2525153f, 7);
+                mem.fCameraFront[0].Should().BeApproximately(0.8136908f, 7);
+                mem.fCameraFront[1].Should().BeApproximately(-0.3139677f, 7);
+                mem.fCameraFront[2].Should().BeApproximately(-0.4892152f, 7);
+                new string(mem.identity).Should().BeEquivalentTo(@"{""name"":""Reiga Fiercecrusher"",""profession"":2,""spec"":18,""race"":1,""map_id"":1206,""world_id"":268435460,""team_color_id"":0,""commander"":false,""map"":1206,""fov"":0.960,""uisz"":1}");
+                mem.context.socketAddressFamily.Should().Be(AddressFamily.InterNetwork);
+                mem.context.socketAddress4[0].Should().Be(18);
+                mem.context.socketAddress4[1].Should().Be(197);
+                mem.context.socketAddress4[2].Should().Be(217);
+                mem.context.socketAddress4[3].Should().Be(165);
+                mem.context.socketPort.Should().Be(0);
+                mem.context.mapId.Should().Be(1206);
+                mem.context.mapType.Should().Be((uint)MapType.PublicMini);
+                mem.context.shardId.Should().Be(268435460u);
+                mem.context.instance.Should().Be(0);
+                mem.context.buildId.Should().Be(99552);
+                mem.context.uiState.Should().Be(UiState.IsCompassRotationEnabled | UiState.DoesGameHaveFocus | UiState.IsCompetitiveMode | UiState.DoesAnyInputHaveFocus);
+                mem.context.compassWidth.Should().Be(362);
+                mem.context.compassHeight.Should().Be(229);
+                mem.context.compassRotation.Should().BeApproximately(-2.11212f, 5);
+                mem.context.playerMapX.Should().BeApproximately(14400.01f, 2);
+                mem.context.playerMapY.Should().BeApproximately(18180.19f, 2);
+                mem.context.mapCenterX.Should().BeApproximately(14400.01f, 2);
+                mem.context.mapCenterY.Should().BeApproximately(18180.19f, 2);
+                mem.context.mapScale.Should().Be(1);
+                mem.context.processId.Should().Be(15101);
+                mem.context.mount.Should().Be(MountType.Griffon);
+            }
+        }
+
+        [SkippableFact]
+        public void DisposeCorrectlyTest()
+        {
+            // Named memory mapped files aren't supported on Unix based systems.
+            // So we need to skip this test.
+            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
+
+            var reader = new Gw2MumbleClientReader();
+            reader.Dispose();
+            Assert.ThrowsAny<ObjectDisposedException>(() => reader.Read());
+        }
+    }
+}

--- a/Gw2Sharp.Tests/Mumble/Gw2MumbleClientTests.cs
+++ b/Gw2Sharp.Tests/Mumble/Gw2MumbleClientTests.cs
@@ -1,10 +1,11 @@
 using System;
-using System.IO.MemoryMappedFiles;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using AutoFixture.Xunit2;
 using FluentAssertions;
-using Gw2Sharp.Models;
+using FluentAssertions.Execution;
 using Gw2Sharp.Mumble;
-using Gw2Sharp.Mumble.Models;
+using NSubstitute;
 using Xunit;
 
 namespace Gw2Sharp.Tests.Mumble
@@ -13,128 +14,110 @@ namespace Gw2Sharp.Tests.Mumble
     {
         private bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
-        [Fact]
-        public void ThrowsPlatformNotSupportedExceptionIfNotWindowsTest()
+        private Gw2LinkedMem GetLinkedMem()
         {
-            Action createClient = () =>
+            using var resourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream($"Gw2Sharp.Tests.TestFiles.Mumble.MemoryMappedFile.bin");
+            var buffer = new byte[resourceStream.Length];
+            resourceStream.Read(buffer, 0, buffer.Length);
+
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            try
             {
-                using var client = new Gw2MumbleClient();
-                client.Update();
-            };
-
-            if (this.isWindows)
-                createClient.Should().NotThrow<PlatformNotSupportedException>();
-            else
-                createClient.Should().Throw<PlatformNotSupportedException>();
+                return Marshal.PtrToStructure<Gw2LinkedMem>(handle.AddrOfPinnedObject());
+            }
+            finally
+            {
+                handle.Free();
+            }
         }
 
-        [SkippableFact]
-        public void ReadStructCorrectlyTest()
+        [Fact]
+        public void ReadsCorrectlyTest()
         {
-            // Named memory mapped files aren't supported on Unix based systems.
-            // So we need to skip this test.
-            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
+            using var reader = Substitute.For<IGw2MumbleClientReader>();
+            reader.IsOpen.Returns(false);
+            reader.Read().Returns(GetLinkedMem());
 
-            using var memorySource = Assembly.GetExecutingAssembly().GetManifestResourceStream($"Gw2Sharp.Tests.TestFiles.Mumble.MemoryMappedFile.bin");
-            using var memoryMappedFile = MemoryMappedFile.CreateOrOpen(Gw2MumbleClient.DEFAULT_MUMBLE_LINK_MAP_NAME, memorySource.Length);
-            using var stream = memoryMappedFile.CreateViewStream();
-            memorySource.CopyTo(stream);
+            using (var client = new Gw2MumbleClient(_ => reader))
+            {
+                client.Update();
 
-            using var client = new Gw2MumbleClient();
-            client.Update();
-            Assert.True(client.IsAvailable);
-            Assert.Equal(2, client.Version);
-            Assert.Equal(7244, client.Tick);
-            Assert.Equal(-68.27287, client.AvatarPosition.X, 5);
-            Assert.Equal(119.209, client.AvatarPosition.Y, 3);
-            Assert.Equal(-6.154798, client.AvatarPosition.Z, 6);
-            Assert.Equal(0.8834972, client.AvatarFront.X, 7);
-            Assert.Equal(0, client.AvatarFront.Y, 5);
-            Assert.Equal(-0.4684365, client.AvatarFront.Z, 7);
-            Assert.Equal(Gw2MumbleClient.MUMBLE_LINK_GAME_NAME_GUILD_WARS_2, client.Name);
-            Assert.Equal(-78.08988, client.CameraPosition.X, 5);
-            Assert.Equal(126.4892, client.CameraPosition.Y, 4);
-            Assert.Equal(-0.2525153, client.CameraPosition.Z, 7);
-            Assert.Equal(0.8136908, client.CameraFront.X, 7);
-            Assert.Equal(-0.3139677, client.CameraFront.Y, 7);
-            Assert.Equal(-0.4892152, client.CameraFront.Z, 7);
-            Assert.Equal(@"{""name"":""Reiga Fiercecrusher"",""profession"":2,""spec"":18,""race"":1,""map_id"":1206,""world_id"":268435460,""team_color_id"":0,""commander"":false,""map"":1206,""fov"":0.960,""uisz"":1}", client.RawIdentity);
-            Assert.Equal("Reiga Fiercecrusher", client.CharacterName);
-            Assert.Equal(ProfessionType.Warrior, client.Profession);
-            Assert.Equal(RaceType.Charr, client.Race);
-            Assert.Equal(18, client.Specialization);
-            Assert.Equal(0, client.TeamColorId);
-            Assert.False(client.IsCommander);
-            Assert.Equal(0.960, client.FieldOfView);
-            Assert.Equal(UiSize.Normal, client.UiSize);
-            Assert.Equal("18.197.217.165", client.ServerAddress);
-            Assert.Equal(0, client.ServerPort);
-            Assert.Equal(1206, client.MapId);
-            Assert.Equal(MapType.PublicMini, client.MapType);
-            Assert.Equal(268435460u, client.ShardId);
-            Assert.Equal(0u, client.Instance);
-            Assert.Equal(99552, client.BuildId);
-            Assert.False(client.IsMapOpen);
-            Assert.False(client.IsCompassTopRight);
-            Assert.True(client.IsCompassRotationEnabled);
-            Assert.True(client.DoesGameHaveFocus);
-            Assert.True(client.IsCompetitiveMode);
-            Assert.True(client.DoesAnyInputHaveFocus);
-            Assert.False(client.IsInCombat);
-            Assert.Equal(362, client.Compass.Width);
-            Assert.Equal(229, client.Compass.Height);
-            Assert.Equal(-2.11212, client.CompassRotation, 5);
-            Assert.Equal(14400.01, client.PlayerLocationMap.X, 2);
-            Assert.Equal(18180.19, client.PlayerLocationMap.Y, 2);
-            Assert.Equal(14400.01, client.MapCenter.X, 2);
-            Assert.Equal(18180.19, client.MapCenter.Y, 2);
-            Assert.Equal(1, client.MapScale);
-            Assert.Equal(15101u, client.ProcessId);
-            Assert.Equal(MountType.Griffon, client.Mount);
+                reader.Received(1).Open();
+                reader.Received(1).Read();
+            }
+
+            reader.Received(1).Dispose();
         }
 
-        [SkippableFact]
+        [Fact]
         public void DisposeCorrectlyTest()
         {
-            // Named memory mapped files aren't supported on Unix based systems.
-            // So we need to skip this test.
-            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
-
-            var client = new Gw2MumbleClient();
+            using var reader = Substitute.For<IGw2MumbleClientReader>();
+            var client = new Gw2MumbleClient(_ => reader);
             client.Dispose();
-            Assert.ThrowsAny<ObjectDisposedException>(() => client.Update());
+
+            Action act = () => client.Update();
+            act.Should().Throw<ObjectDisposedException>();
         }
 
-        [SkippableFact]
+        [Fact]
         public void DisposeChildOnlyCorrectlyTest()
         {
-            // Named memory mapped files aren't supported on Unix based systems.
-            // So we need to skip this test.
-            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
-
-            using var rootClient = new Gw2MumbleClient();
+            using var reader = Substitute.For<IGw2MumbleClientReader>();
+            using var rootClient = new Gw2MumbleClient(_ => reader);
             var childClientA = rootClient["CinderSteeltemper"];
             var childClientB = rootClient["VishenSteelshot"];
             childClientA.Dispose();
-            Assert.ThrowsAny<ObjectDisposedException>(() => childClientA.Update());
-            childClientB.Update(); // Sibling should not be disposed
-            rootClient.Update(); // Root should not be disposed
+
+            using (new AssertionScope())
+            {
+                Action actRoot = () => rootClient.Update();
+                Action actChildA = () => childClientA.Update();
+                Action actChildB = () => childClientB.Update();
+
+                // Only child A should be disposed
+                actRoot.Should().NotThrow();
+                actChildA.Should().Throw<ObjectDisposedException>();
+                actChildB.Should().NotThrow();
+            }
         }
 
-        [SkippableFact]
+        [Fact]
         public void DisposeAllFromRootCorrectlyTest()
         {
-            // Named memory mapped files aren't supported on Unix based systems.
-            // So we need to skip this test.
-            Skip.IfNot(this.isWindows, "Mumble Link is only supported in Windows");
-
-            var rootClient = new Gw2MumbleClient();
+            using var reader = Substitute.For<IGw2MumbleClientReader>();
+            var rootClient = new Gw2MumbleClient(_ => reader);
             var childClientA = rootClient["CinderSteeltemper"];
             var childClientB = rootClient["VishenSteelshot"];
             rootClient.Dispose();
-            Assert.ThrowsAny<ObjectDisposedException>(() => rootClient.Update());
-            Assert.ThrowsAny<ObjectDisposedException>(() => childClientA.Update());
-            Assert.ThrowsAny<ObjectDisposedException>(() => childClientB.Update());
+
+            using (new AssertionScope())
+            {
+                Action actRoot = () => rootClient.Update();
+                Action actChildA = () => childClientA.Update();
+                Action actChildB = () => childClientB.Update();
+
+                // Everything should be disposed
+                actRoot.Should().Throw<ObjectDisposedException>();
+                actChildA.Should().Throw<ObjectDisposedException>();
+                actChildB.Should().Throw<ObjectDisposedException>();
+            }
+        }
+
+        [Theory]
+        [AutoData]
+        public void UsesSameInstanceForSameNamesTest(string mumbleLinkName)
+        {
+            using var client = new Gw2MumbleClient(x => Substitute.For<IGw2MumbleClientReader>());
+            var childClientA = client[mumbleLinkName];
+            var childClientB = client[mumbleLinkName];
+            var childClientAA = childClientA[mumbleLinkName];
+
+            using (new AssertionScope())
+            {
+                childClientA.Should().BeSameAs(childClientB);
+                childClientA.Should().BeSameAs(childClientAA);
+            }
         }
     }
 }

--- a/Gw2Sharp/Gw2Client.cs
+++ b/Gw2Sharp/Gw2Client.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.Versioning;
 using Gw2Sharp.Mumble;
 using Gw2Sharp.WebApi;
 
@@ -10,7 +9,7 @@ namespace Gw2Sharp
     /// </summary>
     public class Gw2Client : IGw2Client
     {
-        private readonly IGw2MumbleClient? mumble;
+        private readonly IGw2MumbleClient mumble;
         private readonly IGw2WebApiClient webApi;
 
         /// <summary>
@@ -28,21 +27,12 @@ namespace Gw2Sharp
             if (connection == null)
                 throw new ArgumentNullException(nameof(connection));
 
-#if NET5_0_OR_GREATER
-            if (OperatingSystem.IsWindows())
-                this.mumble = new Gw2MumbleClient();
-#else
-            this.mumble = new Gw2MumbleClient();
-#endif
+            this.mumble = new Gw2MumbleClient(connection.MumbleClientReaderFactory);
             this.webApi = new Gw2WebApiClient(connection, this);
         }
 
         /// <inheritdoc />
-#if NET5_0_OR_GREATER
-        [SupportedOSPlatform("windows")]
-#endif
-        public virtual IGw2MumbleClient Mumble =>
-            this.mumble ?? throw new PlatformNotSupportedException("Mumble Link is only available on Windows platforms");
+        public virtual IGw2MumbleClient Mumble => this.mumble;
 
         /// <inheritdoc />
         public virtual IGw2WebApiClient WebApi => this.webApi;
@@ -57,15 +47,15 @@ namespace Gw2Sharp
         /// <param name="disposing">Dispose managed resources.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!this.isDisposed)
-            {
-                if (disposing)
-                {
-                    this.mumble?.Dispose();
-                }
+            if (this.isDisposed)
+                return;
 
-                this.isDisposed = true;
+            if (disposing)
+            {
+                this.mumble?.Dispose();
             }
+
+            this.isDisposed = true;
         }
 
         /// <inheritdoc />

--- a/Gw2Sharp/IConnection.cs
+++ b/Gw2Sharp/IConnection.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Gw2Sharp.Mumble;
 using Gw2Sharp.WebApi;
 using Gw2Sharp.WebApi.Caching;
 using Gw2Sharp.WebApi.Http;
 using Gw2Sharp.WebApi.Middleware;
+using static Gw2Sharp.Mumble.IGw2MumbleClientReader;
 
 namespace Gw2Sharp
 {
@@ -55,13 +57,11 @@ namespace Gw2Sharp
         /// <summary>
         /// Gets the HTTP client that's used for the API requests.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><c>value</c> is <see langword="null"/>.</exception>
         IHttpClient HttpClient { get; }
 
         /// <summary>
         /// Gets the cache controller that's used for API requests.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><c>value</c> is <see langword="null"/>.</exception>
         ICacheMethod CacheMethod { get; }
 
         /// <summary>
@@ -73,7 +73,6 @@ namespace Gw2Sharp
         /// <summary>
         /// Gets the cache controller that's used for render file API requests.
         /// </summary>
-        /// <exception cref="ArgumentNullException"><c>value</c> is <see langword="null"/>.</exception>
         ICacheMethod RenderCacheMethod { get; }
 
         /// <summary>
@@ -87,5 +86,12 @@ namespace Gw2Sharp
         /// This value can be used to determine if the list has changed.
         /// </summary>
         int MiddlewareHashCode { get; }
+
+        /// <summary>
+        /// Gets the Mumble client reader factory.
+        /// This factory has the Mumble Link name as parameter, and should return a new instance of <see cref="IGw2MumbleClientReader"/>.
+        /// Defaults to <see cref="Gw2MumbleClientReader"/> on Windows.
+        /// </summary>
+        Gw2MumbleLinkReaderFactory MumbleClientReaderFactory { get; }
     }
 }

--- a/Gw2Sharp/IGw2Client.cs
+++ b/Gw2Sharp/IGw2Client.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.Versioning;
 using Gw2Sharp.Mumble;
 using Gw2Sharp.WebApi;
 
@@ -13,10 +12,6 @@ namespace Gw2Sharp
         /// <summary>
         /// Gets the Mumble Link client API.
         /// </summary>
-        /// <exception cref="PlatformNotSupportedException">Mumble Link is not available on non-Windows platforms.</exception>
-#if NET5_0_OR_GREATER
-        [SupportedOSPlatform("windows")]
-#endif
         IGw2MumbleClient Mumble { get; }
 
         /// <summary>

--- a/Gw2Sharp/Mumble/Gw2LinkedMem.cs
+++ b/Gw2Sharp/Mumble/Gw2LinkedMem.cs
@@ -13,20 +13,56 @@ using Gw2Sharp.Mumble.Models;
 
 namespace Gw2Sharp.Mumble
 {
+    /// <summary>
+    /// The Guild Wars 2 Mumble Link struct.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
-    internal unsafe struct Gw2LinkedMem
+    public unsafe struct Gw2LinkedMem
     {
+        /// <summary>
+        /// The Mumble Link struct size.
+        /// </summary>
         public const int SIZE = 5460;
 
+        /// <summary>
+        /// The Mumble Link version.
+        /// </summary>
         [FieldOffset(0)] public uint uiVersion;
+        /// <summary>
+        /// The Mumble Link tick count.
+        /// </summary>
         [FieldOffset(4)] public uint uiTick;
+        /// <summary>
+        /// The avatar position.
+        /// </summary>
         [FieldOffset(8)] public fixed float fAvatarPosition[3];
+        /// <summary>
+        /// The avatar front.
+        /// </summary>
         [FieldOffset(20)] public fixed float fAvatarFront[3];
+        /// <summary>
+        /// The game name.
+        /// </summary>
         [FieldOffset(44)] public fixed char name[256];
+        /// <summary>
+        /// The camera position.
+        /// </summary>
         [FieldOffset(556)] public fixed float fCameraPosition[3];
+        /// <summary>
+        /// The camera front.
+        /// </summary>
         [FieldOffset(568)] public fixed float fCameraFront[3];
+        /// <summary>
+        /// The Mumble Link identity.
+        /// </summary>
         [FieldOffset(592)] public fixed char identity[256];
+        /// <summary>
+        /// The context struct size.
+        /// </summary>
         [FieldOffset(1104)] public uint contextLen;
+        /// <summary>
+        /// The Mumble Link context.
+        /// </summary>
         [FieldOffset(1108)] public Gw2Context context;
 
         // Unused fields
@@ -42,36 +78,108 @@ namespace Gw2Sharp.Mumble
         // Total struct size is 5460 bytes
     }
 
+    /// <summary>
+    /// Guild Wars 2 specific Mumble Link context struct.
+    /// </summary>
     [StructLayout(LayoutKind.Explicit)]
-    internal unsafe struct Gw2Context
+    public unsafe struct Gw2Context
     {
+        /// <summary>
+        /// The socket address struct size.
+        /// </summary>
         public const int SOCKET_ADDRESS_SIZE = 28;
 
+        /// <summary>
+        /// The raw socket address data.
+        /// </summary>
         [FieldOffset(0)] public fixed byte socketAddress[SOCKET_ADDRESS_SIZE];
 
+        /// <summary>
+        /// The socket address family.
+        /// </summary>
         [FieldOffset(0)] private ushort _socketAddressFamily;
 
+        /// <summary>
+        /// The socket address family.
+        /// </summary>
         public AddressFamily socketAddressFamily => (AddressFamily)this._socketAddressFamily;
 
+        /// <summary>
+        /// The socket port.
+        /// </summary>
         [FieldOffset(2)] public ushort socketPort;
+        /// <summary>
+        /// The socket address in IPv4 format.
+        /// </summary>
         [FieldOffset(4)] public fixed byte socketAddress4[4];
+        /// <summary>
+        /// The socket address in IPv6 format.
+        /// </summary>
         [FieldOffset(8)] public fixed ushort socketAddress6[8];
 
+        /// <summary>
+        /// The map id.
+        /// </summary>
         [FieldOffset(28)] public uint mapId;
+        /// <summary>
+        /// The map type.
+        /// </summary>
         [FieldOffset(32)] public uint mapType;
+        /// <summary>
+        /// The shard id.
+        /// </summary>
         [FieldOffset(36)] public uint shardId;
+        /// <summary>
+        /// The instance.
+        /// </summary>
         [FieldOffset(40)] public uint instance;
+        /// <summary>
+        /// The build id.
+        /// </summary>
         [FieldOffset(44)] public uint buildId;
+        /// <summary>
+        /// The UI state.
+        /// </summary>
         [FieldOffset(48)] public UiState uiState;
+        /// <summary>
+        /// The compass width.
+        /// </summary>
         [FieldOffset(52)] public ushort compassWidth;
+        /// <summary>
+        /// The compass height.
+        /// </summary>
         [FieldOffset(54)] public ushort compassHeight;
+        /// <summary>
+        /// The compass rotation.
+        /// </summary>
         [FieldOffset(56)] public float compassRotation;
+        /// <summary>
+        /// The player map x-coordinate.
+        /// </summary>
         [FieldOffset(60)] public float playerMapX;
+        /// <summary>
+        /// The player map y-coordinate.
+        /// </summary>
         [FieldOffset(64)] public float playerMapY;
+        /// <summary>
+        /// The map center x-coordinate.
+        /// </summary>
         [FieldOffset(68)] public float mapCenterX;
+        /// <summary>
+        /// The map center y-coordinate.
+        /// </summary>
         [FieldOffset(72)] public float mapCenterY;
+        /// <summary>
+        /// The map scale.
+        /// </summary>
         [FieldOffset(76)] public float mapScale;
+        /// <summary>
+        /// The process id.
+        /// </summary>
         [FieldOffset(80)] public uint processId;
+        /// <summary>
+        /// The mount.
+        /// </summary>
         [FieldOffset(84)] public MountType mount;
 
         // Total struct size is 256 bytes

--- a/Gw2Sharp/Mumble/Gw2MumbleClient.cs
+++ b/Gw2Sharp/Mumble/Gw2MumbleClient.cs
@@ -385,7 +385,7 @@ namespace Gw2Sharp.Mumble
                 this.reader.Dispose();
 
                 // Only dispose the full client cache tree if we are the default one and are the root
-                if (this.mumbleLinkName == DEFAULT_MUMBLE_LINK_MAP_NAME)
+                if (this.mumbleLinkName == DEFAULT_MUMBLE_LINK_MAP_NAME && this.isRoot)
                 {
                     foreach (var reference in this.mumbleClientCache.Select(x => x.Value))
                     {

--- a/Gw2Sharp/Mumble/Gw2MumbleClientReader.cs
+++ b/Gw2Sharp/Mumble/Gw2MumbleClientReader.cs
@@ -1,0 +1,97 @@
+using System;
+using System.IO.MemoryMappedFiles;
+
+namespace Gw2Sharp.Mumble
+{
+    /// <summary>
+    /// The default Guild Wars 2 Mumble client reader.
+    /// Uses the official Mumble Link API, which is only available on Windows operating systems, or in Windows-emulated environments.
+    /// </summary>
+#if NET5_0_OR_GREATER
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
+    public class Gw2MumbleClientReader : IGw2MumbleClientReader
+    {
+        private MemoryMappedFile? file;
+        private MemoryMappedViewAccessor? accessor;
+
+        /// <summary>
+        /// Creates a new <see cref="Gw2MumbleClientReader"/>.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">Only Windows operating systems are supported.</exception>
+        public Gw2MumbleClientReader()
+        {
+#if NET5_0_OR_GREATER
+            if (!OperatingSystem.IsWindows())
+#else
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+#endif
+                throw new PlatformNotSupportedException("Only Windows operating systems support the Mumble Link");
+        }
+
+        /// <inheritdoc/>
+        public bool IsOpen { get; private set; }
+
+        /// <inheritdoc/>
+        public void Open(string mumbleLinkName)
+        {
+            this.file = MemoryMappedFile.CreateOrOpen(mumbleLinkName, Gw2LinkedMem.SIZE, MemoryMappedFileAccess.ReadWrite);
+            this.accessor = this.file.CreateViewAccessor();
+            this.IsOpen = true;
+        }
+
+        /// <inheritdoc/>
+        public void Close()
+        {
+            this.accessor?.Dispose();
+            this.file?.Dispose();
+
+            this.accessor = null;
+            this.file = null;
+            this.IsOpen = false;
+        }
+
+        /// <inheritdoc/>
+        public Gw2LinkedMem Read()
+        {
+            if (this.isDisposed)
+                throw new ObjectDisposedException(nameof(Gw2MumbleClientReader));
+            if (this.file is null || this.accessor is null)
+                throw new InvalidOperationException("The reader has to be opened first");
+
+            this.accessor.Read<Gw2LinkedMem>(0, out var mem);
+            return mem;
+        }
+
+
+#region IDisposable Support
+
+        private bool isDisposed = false; // To detect redundant calls
+
+        /// <summary>
+        /// Disposes the object.
+        /// </summary>
+        /// <param name="disposing">Dispose managed resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.isDisposed)
+                return;
+
+            if (disposing)
+            {
+                this.Close();
+            }
+
+            this.isDisposed = true;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+#endregion
+    }
+}

--- a/Gw2Sharp/Mumble/Gw2MumbleClientReader.cs
+++ b/Gw2Sharp/Mumble/Gw2MumbleClientReader.cs
@@ -15,11 +15,16 @@ namespace Gw2Sharp.Mumble
         private MemoryMappedFile? file;
         private MemoryMappedViewAccessor? accessor;
 
+        private readonly string mumbleLinkName;
+
         /// <summary>
         /// Creates a new <see cref="Gw2MumbleClientReader"/>.
         /// </summary>
+        /// <param name="mumbleLinkName">The Mumble Link name.</param>
         /// <exception cref="PlatformNotSupportedException">Only Windows operating systems are supported.</exception>
-        public Gw2MumbleClientReader()
+        /// <exception cref="ArgumentNullException"><paramref name="mumbleLinkName"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="mumbleLinkName"/> is an empty string or only contains whitespaces.</exception>
+        public Gw2MumbleClientReader(string mumbleLinkName)
         {
 #if NET5_0_OR_GREATER
             if (!OperatingSystem.IsWindows())
@@ -27,15 +32,22 @@ namespace Gw2Sharp.Mumble
             if (Environment.OSVersion.Platform != PlatformID.Win32NT)
 #endif
                 throw new PlatformNotSupportedException("Only Windows operating systems support the Mumble Link");
+
+            if (mumbleLinkName is null)
+                throw new ArgumentNullException(nameof(mumbleLinkName));
+            if (string.IsNullOrWhiteSpace(mumbleLinkName))
+                throw new ArgumentException($"'{nameof(mumbleLinkName)}' may not be empty or only contain whitespaces", nameof(mumbleLinkName));
+
+            this.mumbleLinkName = mumbleLinkName;
         }
 
         /// <inheritdoc/>
         public bool IsOpen { get; private set; }
 
         /// <inheritdoc/>
-        public void Open(string mumbleLinkName)
+        public void Open()
         {
-            this.file = MemoryMappedFile.CreateOrOpen(mumbleLinkName, Gw2LinkedMem.SIZE, MemoryMappedFileAccess.ReadWrite);
+            this.file = MemoryMappedFile.CreateOrOpen(this.mumbleLinkName, Gw2LinkedMem.SIZE, MemoryMappedFileAccess.ReadWrite);
             this.accessor = this.file.CreateViewAccessor();
             this.IsOpen = true;
         }
@@ -64,7 +76,7 @@ namespace Gw2Sharp.Mumble
         }
 
 
-#region IDisposable Support
+        #region IDisposable Support
 
         private bool isDisposed = false; // To detect redundant calls
 
@@ -92,6 +104,6 @@ namespace Gw2Sharp.Mumble
             GC.SuppressFinalize(this);
         }
 
-#endregion
+        #endregion
     }
 }

--- a/Gw2Sharp/Mumble/IGw2MumbleClient.cs
+++ b/Gw2Sharp/Mumble/IGw2MumbleClient.cs
@@ -11,11 +11,6 @@ namespace Gw2Sharp.Mumble
     public interface IGw2MumbleClient : IDisposable
     {
         /// <summary>
-        /// The Mumble client reader instance.
-        /// </summary>
-        IGw2MumbleClientReader Reader { get; }
-
-        /// <summary>
         /// Gets a custom named Mumble Link client API.
         /// </summary>
         /// <param name="name">The custom name.</param>
@@ -248,12 +243,5 @@ namespace Gw2Sharp.Mumble
         /// Call this every frame and/or every time you want to update the Mumble Link data before reading.
         /// </summary>
         void Update();
-
-        /// <summary>
-        /// Sets a custom Mumble client reader.
-        /// </summary>
-        /// <typeparam name="T">The reader type.</typeparam>
-        /// <returns>This <see cref="IGw2MumbleClient"/> instance.</returns>
-        IGw2MumbleClient WithReader<T>() where T : IGw2MumbleClientReader, new();
     }
 }

--- a/Gw2Sharp/Mumble/IGw2MumbleClient.cs
+++ b/Gw2Sharp/Mumble/IGw2MumbleClient.cs
@@ -11,6 +11,11 @@ namespace Gw2Sharp.Mumble
     public interface IGw2MumbleClient : IDisposable
     {
         /// <summary>
+        /// The Mumble client reader instance.
+        /// </summary>
+        IGw2MumbleClientReader Reader { get; }
+
+        /// <summary>
         /// Gets a custom named Mumble Link client API.
         /// </summary>
         /// <param name="name">The custom name.</param>
@@ -243,5 +248,12 @@ namespace Gw2Sharp.Mumble
         /// Call this every frame and/or every time you want to update the Mumble Link data before reading.
         /// </summary>
         void Update();
+
+        /// <summary>
+        /// Sets a custom Mumble client reader.
+        /// </summary>
+        /// <typeparam name="T">The reader type.</typeparam>
+        /// <returns>This <see cref="IGw2MumbleClient"/> instance.</returns>
+        IGw2MumbleClient WithReader<T>() where T : IGw2MumbleClientReader, new();
     }
 }

--- a/Gw2Sharp/Mumble/IGw2MumbleClientReader.cs
+++ b/Gw2Sharp/Mumble/IGw2MumbleClientReader.cs
@@ -8,6 +8,13 @@ namespace Gw2Sharp.Mumble
     public interface IGw2MumbleClientReader : IDisposable
     {
         /// <summary>
+        /// A delegate for creating a new <see cref="IGw2MumbleClientReader"/> with a Mumble Link name as parameter.
+        /// </summary>
+        /// <param name="mumbleLinkName">The Mumble Link name.</param>
+        /// <returns>A new <see cref="IGw2MumbleClientReader"/> instance specifically for this Mumble Link name.</returns>
+        public delegate IGw2MumbleClientReader Gw2MumbleLinkReaderFactory(string mumbleLinkName);
+
+        /// <summary>
         /// Whether this reader is open.
         /// </summary>
         bool IsOpen { get; }
@@ -15,8 +22,7 @@ namespace Gw2Sharp.Mumble
         /// <summary>
         /// Opens the reader.
         /// </summary>
-        /// <param name="mumbleLinkName">The Mumble Link name.</param>
-        void Open(string mumbleLinkName);
+        void Open();
 
         /// <summary>
         /// Closes the reader.

--- a/Gw2Sharp/Mumble/IGw2MumbleClientReader.cs
+++ b/Gw2Sharp/Mumble/IGw2MumbleClientReader.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Gw2Sharp.Mumble
+{
+    /// <summary>
+    /// An interface for implementing a reader for the Guild Wars 2 Mumble client.
+    /// </summary>
+    public interface IGw2MumbleClientReader : IDisposable
+    {
+        /// <summary>
+        /// Whether this reader is open.
+        /// </summary>
+        bool IsOpen { get; }
+
+        /// <summary>
+        /// Opens the reader.
+        /// </summary>
+        /// <param name="mumbleLinkName">The Mumble Link name.</param>
+        void Open(string mumbleLinkName);
+
+        /// <summary>
+        /// Closes the reader.
+        /// </summary>
+        void Close();
+
+        /// <summary>
+        /// Reads the Guild Wars 2 Mumble Link data into the <see cref="Gw2LinkedMem"/> struct.
+        /// </summary>
+        /// <returns>The read Guild Wars 2 Mumble Link data as <see cref="Gw2LinkedMem"/>.</returns>
+        Gw2LinkedMem Read();
+    }
+}

--- a/Gw2Sharp/Mumble/Models/UiState.cs
+++ b/Gw2Sharp/Mumble/Models/UiState.cs
@@ -6,7 +6,7 @@ namespace Gw2Sharp.Mumble.Models
     /// The UI state.
     /// </summary>
     [Flags]
-    internal enum UiState : uint
+    public enum UiState : uint
     {
         /// <summary>
         /// Whether the map is currently open.

--- a/Gw2Sharp/Mumble/UnsupportedMumblePlatformClientReader.cs
+++ b/Gw2Sharp/Mumble/UnsupportedMumblePlatformClientReader.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace Gw2Sharp.Mumble
+{
+    /// <summary>
+    /// An unsupported Mumble platform client reader.
+    /// Does nothing besides throwing <see cref="PlatformNotSupportedException"/> for each method.
+    /// </summary>
+    internal sealed class UnsupportedMumblePlatformClientReader : IGw2MumbleClientReader
+    {
+        /// <inheritdoc/>
+        public bool IsOpen =>
+            throw new PlatformNotSupportedException($"Mumble Link is not supported on {Environment.OSVersion.Platform}");
+
+        /// <inheritdoc/>
+        public void Open() =>
+            throw new PlatformNotSupportedException($"Mumble Link is not supported on {Environment.OSVersion.Platform}");
+
+        /// <inheritdoc/>
+        public void Close() =>
+            throw new PlatformNotSupportedException($"Mumble Link is not supported on {Environment.OSVersion.Platform}");
+
+        /// <inheritdoc/>
+        public Gw2LinkedMem Read() =>
+            throw new PlatformNotSupportedException($"Mumble Link is not supported on {Environment.OSVersion.Platform}");
+
+
+        #region IDisposable Support
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This adds support for providing a custom Mumble Link reader. By default this is set to what it always was on Windows. For any other operating system, this is set to a reader that just returns `NotSupportedException`. The functionality effectively stays the same as before.

`SupportedOSPlatformAttribute` has been removed in certain areas because it can't be included anymore with this construction, instead it's now placed explicitly on the default `Gw2MumbleClientReader` that's used on Windows.

A bunch of structs have been publicized because they are necessary for the Mumble Link reader interface.