### PR TITLE
Remove netcoreapp2.1 and add net6.0 for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         dotnet:
+          - net6.0
           - net5.0
           - netcoreapp3.1
-          - netcoreapp2.1
           - net461
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          - windows-2022
         dotnet:
           - net6.0
           - net5.0

--- a/.github/workflows/command-test.yml
+++ b/.github/workflows/command-test.yml
@@ -29,9 +29,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         dotnet:
+          - net6.0
           - net5.0
           - netcoreapp3.1
-          - netcoreapp2.1
           - net461
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/command-test.yml
+++ b/.github/workflows/command-test.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          - windows-2022
         dotnet:
           - net6.0
           - net5.0
@@ -45,7 +45,7 @@ jobs:
 
   sonarcloud:
     name: Analysis
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [pre]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -16,8 +16,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         dotnet:
+          - net6.0
+          - net5.0
           - netcoreapp3.1
-          - netcoreapp2.1
           - net461
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
+          - windows-2022
         dotnet:
           - net6.0
           - net5.0
@@ -30,7 +30,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [test]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   nuget:
     name: NuGet
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Download NuGet packages
         shell: powershell

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   sonarcloud:
     name: Analysis
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'Archomeda/Gw2Sharp'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
       - name: Download docfx

--- a/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
+++ b/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Nullable>annotations</Nullable>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>

--- a/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
+++ b/Gw2Sharp.Tests/Gw2Sharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Nullable>annotations</Nullable>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>


### PR DESCRIPTION
.NET Core 2.1 hasn't been supported for some time now, but we were still testing against it. This is now removed. I've replaced it with .NET 6.

Gw2Sharp itself doesn't target .NET 6 yet.

Will start merging this once GitHub actions include .NET 6 by default for ubuntu agents...