### PR TITLE
Add missing equipment tab slot name

### DIFF
--- a/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.bulk.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.bulk.json
@@ -1,6 +1,7 @@
 [
   {
     "tab": 1,
+    "name": "Tab 1",
     "is_active": true,
     "equipment": [
       {
@@ -125,6 +126,7 @@
   },
   {
     "tab": 2,
+    "name": "Tab 2",
     "is_active": false,
     "equipment": [
       {

--- a/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.single.json
+++ b/Gw2Sharp.Tests/TestFiles/Characters/CharactersIdEquipmentTabs.single.json
@@ -1,5 +1,6 @@
 {
   "tab": 1,
+  "name": "Tab 1",
   "is_active": true,
   "equipment": [
     {

--- a/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentTabSlot.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Characters/CharacterEquipmentTabSlot.cs
@@ -22,6 +22,11 @@ namespace Gw2Sharp.WebApi.V2.Models
         public int Tab { get; set; }
 
         /// <summary>
+        /// The equipment template name.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>
         /// Whether this equipment tab slot is current active.
         /// </summary>
         public bool IsActive { get; set; }


### PR DESCRIPTION
The names for the equipment tab slots were missing.