### PR TITLE
Make Skill Icon nullable.

### DIFF
--- a/Gw2Sharp/WebApi/V2/Models/Skills/Skill.cs
+++ b/Gw2Sharp/WebApi/V2/Models/Skills/Skill.cs
@@ -27,7 +27,7 @@ namespace Gw2Sharp.WebApi.V2.Models
         /// <summary>
         /// The skill icon URL.
         /// </summary>
-        public RenderUrl Icon { get; set; }
+        public RenderUrl? Icon { get; set; }
 
         /// <summary>
         /// The skill specialization.


### PR DESCRIPTION
Some skills appear to have no icon returned by the API.

For example: https://api.guildwars2.com/v2/skills?ids=52116

```json
[
  {
    "name": "Largos' Domain",
    "facts": [
      {
        "text": "Recharge",
        "type": "Recharge",
        "icon": "https://render.guildwars2.com/file/D767B963D120F077C3B163A05DC05A7317D7DB70/156651.png",
        "value": 2
      },
      {
        "text": "Apply Buff/Condition",
        "type": "Buff",
        "icon": "https://render.guildwars2.com/file/FB5C627D1A6A46807AF77165604A27FE804B056F/2039793.png",
        "duration": 20,
        "status": "Waterlogged",
        "description": "As you become more waterlogged, you become more susceptible to the largos' water magic. If you become fully waterlogged at maximum stacks, you will be assassinated.",
        "apply_count": 1
      }
    ],
    "description": "",
    "flags": [],
    "id": 52116,
    "chat_link": "[&BpTLAAA=]"
  }
]
```

When the Skill Icon property isn't nullable, checking if it's `!= ""` will throw a NRE because the implicit cast to a string attempts to access the Url property which _is_ null because the struct was `default`.  If nullable, then it won't be `default` and the issue is avoided.