### PR TITLE
Fix /v2/raids endpoint 404

### DIFF
--- a/Gw2Sharp/WebApi/V2/Clients/Raids/RaidsClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Raids/RaidsClient.cs
@@ -6,7 +6,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
     /// <summary>
     /// A client of the Guild Wars 2 API v2 raid endpoint.
     /// </summary>
-    [EndpointPath("raid")]
+    [EndpointPath("raids")]
     public class RaidsClient : BaseEndpointBulkAllClient<Raid, string>, IRaidsClient
     {
         /// <summary>


### PR DESCRIPTION
There's a typo in the attribute, causing a 404 upon requesting.

Fixes #122 