### PR TITLE
IAccountProgressionClient:  add "unlocks" scope to tooltip

### DIFF
--- a/Gw2Sharp/WebApi/V2/Clients/Account/IAccountClient.cs
+++ b/Gw2Sharp/WebApi/V2/Clients/Account/IAccountClient.cs
@@ -152,7 +152,7 @@ namespace Gw2Sharp.WebApi.V2.Clients
 
         /// <summary>
         /// Gets the progression.
-        /// Requires scopes: account, progression.
+        /// Requires scopes: account, progression, unlocks.
         /// </summary>
         IAccountProgressionClient Progression { get; }
 


### PR DESCRIPTION
fixes this tooltip:
![image](https://user-images.githubusercontent.com/43114787/187181937-2cb1114a-86c9-4a89-9437-b25369b5619c.png)

because without unlocks scope this exception was thrown:
![image](https://user-images.githubusercontent.com/43114787/187181891-7241b0d4-9234-42e5-b629-ee148b78cf78.png)
