### PR TITLE
Rework RequestException temporarily as a less breaking change

### DIFF
--- a/Gw2Sharp/WebApi/Exceptions/RequestException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/RequestException.cs
@@ -13,7 +13,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, string message) :
             this(request, null, message, null)
         { }
@@ -24,7 +24,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message) :
             this(request, response, message, null)
         { }
@@ -35,7 +35,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
         public RequestException(IWebApiRequest request, string message, Exception? innerException) :
             this(request, null, message, innerException)
         { }

--- a/Gw2Sharp/WebApi/Exceptions/RequestException.cs
+++ b/Gw2Sharp/WebApi/Exceptions/RequestException.cs
@@ -6,16 +6,17 @@ namespace Gw2Sharp.WebApi.Exceptions
     /// <summary>
     /// A generic request exception used for the web API.
     /// </summary>
-    public class RequestException : RequestException<string>
+    public class RequestException : Exception
     {
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
         /// </summary>
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
         public RequestException(IWebApiRequest request, string message) :
-            base(request, message) { }
+            this(request, null, message, null)
+        { }
 
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
@@ -23,9 +24,10 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
         public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message) :
-            base(request, response, message) { }
+            this(request, response, message, null)
+        { }
 
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
@@ -33,9 +35,10 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="request">The original request.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <c>null</c>.</exception>
         public RequestException(IWebApiRequest request, string message, Exception? innerException) :
-            base(request, message, innerException) { }
+            this(request, null, message, innerException)
+        { }
 
         /// <summary>
         /// Creates a new <see cref="RequestException" />.
@@ -44,55 +47,7 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <param name="response">The response.</param>
         /// <param name="message">The message.</param>
         /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
-        public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message, Exception innerException) :
-            base(request, response, message, innerException) { }
-    }
-
-
-    /// <summary>
-    /// A generic request exception used for the web API.
-    /// </summary>
-    /// <typeparam name="TResponse">The response object.</typeparam>
-    public class RequestException<TResponse> : Exception
-    {
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
-        public RequestException(IWebApiRequest request, string message) :
-            this(request, null, message, null) { }
-
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="response">The response.</param>
-        /// <param name="message">The message.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
-        public RequestException(IWebApiRequest request, IWebApiResponse<TResponse>? response, string message) :
-            this(request, response, message, null) { }
-
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="message">The message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
-        public RequestException(IWebApiRequest request, string message, Exception? innerException) :
-            this(request, null, message, innerException) { }
-
-        /// <summary>
-        /// Creates a new <see cref="RequestException{TResponse}" />.
-        /// </summary>
-        /// <param name="request">The original request.</param>
-        /// <param name="response">The response.</param>
-        /// <param name="message">The message.</param>
-        /// <param name="innerException">The inner exception.</param>
-        public RequestException(IWebApiRequest request, IWebApiResponse<TResponse>? response, string message, Exception? innerException) :
+        public RequestException(IWebApiRequest request, IWebApiResponse<string>? response, string message, Exception? innerException) :
             base(message, innerException)
         {
             this.Request = request ?? throw new ArgumentNullException(nameof(request));
@@ -107,6 +62,64 @@ namespace Gw2Sharp.WebApi.Exceptions
         /// <summary>
         /// Gets the response.
         /// </summary>
-        public IWebApiResponse<TResponse>? Response { get; }
+        public IWebApiResponse<string>? Response { get; }
+    }
+
+
+    /// <summary>
+    /// A generic request exception used for the web API.
+    /// </summary>
+    /// <typeparam name="TResponse">The response object.</typeparam>
+    public class RequestException<TResponse> : RequestException
+    {
+        /// <summary>
+        /// Creates a new <see cref="RequestException{TResponse}" />.
+        /// </summary>
+        /// <param name="request">The original request.</param>
+        /// <param name="message">The message.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
+        public RequestException(IWebApiRequest request, string message) :
+            this(request, null, message, null)
+        { }
+
+        /// <summary>
+        /// Creates a new <see cref="RequestException{TResponse}" />.
+        /// </summary>
+        /// <param name="request">The original request.</param>
+        /// <param name="response">The response.</param>
+        /// <param name="message">The message.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
+        public RequestException(IWebApiRequest request, IWebApiResponse<TResponse>? response, string message) :
+            this(request, response, message, null)
+        { }
+
+        /// <summary>
+        /// Creates a new <see cref="RequestException{TResponse}" />.
+        /// </summary>
+        /// <param name="request">The original request.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="request"/> or <paramref name="message"/> is <see langword="null"/>.</exception>
+        public RequestException(IWebApiRequest request, string message, Exception? innerException) :
+            this(request, null, message, innerException)
+        { }
+
+        /// <summary>
+        /// Creates a new <see cref="RequestException{TResponse}" />.
+        /// </summary>
+        /// <param name="request">The original request.</param>
+        /// <param name="response">The response.</param>
+        /// <param name="message">The message.</param>
+        /// <param name="innerException">The inner exception.</param>
+        public RequestException(IWebApiRequest request, IWebApiResponse<TResponse>? response, string message, Exception? innerException) :
+            base(request, null, message, innerException)
+        {
+            this.Response = response;
+        }
+
+        /// <summary>
+        /// Gets the response.
+        /// </summary>
+        public new IWebApiResponse<TResponse>? Response { get; }
     }
 }


### PR DESCRIPTION
This is a less breaking change that can function as a transition period for the full exception handling rework. Version 2.0 is still a bit off, and this will at least ease the pain of handling Gw2Sharp exceptions via the non-generic RequestException as it was meant to be in the first place, but somehow didn't end up how it was supposed to.

It's a less than ideal change due to the `Response` property that's now marked as `new` in the generic `RequestException<T>`, which means that the non-generic `RequestException.Response` won't be set (and is hidden) when `RequestException<T>.Response` is used instead. See the [C# documentation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/new-modifier).

See #96 for the full change that will happen in v2.0, which includes a deletion of the generic variant of `RequestException<T>`.