### PR TITLE
Token in GET parameters in case Headers authentication is down

### DIFF
--- a/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
+++ b/Gw2Sharp.Tests/WebApi/V2/Clients/BaseEndpointClientTests.cs
@@ -227,7 +227,7 @@ namespace Gw2Sharp.Tests.WebApi.V2.Clients
                 uri = builder.Uri;
             }
 
-            Assert.Equal(uri.AbsoluteUri, callInfo.ArgAt<IWebApiRequest>(0).Options.Url.AbsoluteUri);
+            Assert.Equal(uri.AbsoluteUri, callInfo.ArgAt<IWebApiRequest>(0).Options.UrlWithoutAuth.AbsoluteUri);
             var requestHeaders = callInfo.ArgAt<IWebApiRequest>(0).Options.RequestHeaders;
             Assert.Contains(new KeyValuePair<string, string>("Accept", "application/json"), requestHeaders);
             Assert.Contains(new KeyValuePair<string, string>("User-Agent", ((Gw2WebApiBaseClient)client).Connection.UserAgent), requestHeaders);

--- a/Gw2Sharp/WebApi/Http/WebApiRequestOptions.cs
+++ b/Gw2Sharp/WebApi/Http/WebApiRequestOptions.cs
@@ -64,6 +64,22 @@ namespace Gw2Sharp.WebApi.Http
             }
         }
 
+        /// <summary>
+        /// The URL without the authentication parameter.
+        /// </summary>
+        public Uri UrlWithoutAuth
+        {
+            get
+            {
+                var builder = new UriBuilder(this.BaseUrl);
+                builder.Path += this.EndpointPath;
+                if (!string.IsNullOrEmpty(this.PathSuffix))
+                    builder.Path += !this.PathSuffix.StartsWith("/", StringComparison.InvariantCulture) ? "/" : string.Empty + this.PathSuffix;
+                builder.Query = string.Join("&", this.EndpointQuery.Where(x => x.Key != "access_token").Select(x => $"{Uri.EscapeDataString(x.Key)}{(x.Value != null ? $"={Uri.EscapeDataString(x.Value)}" : "")}"));
+                return builder.Uri;
+            }
+        }
+
 #pragma warning disable CA2227 // Collection properties should be read only
         /// <summary>
         /// The request headers to use in the web request.

--- a/Gw2Sharp/WebApi/V2/RequestBuilder.cs
+++ b/Gw2Sharp/WebApi/V2/RequestBuilder.cs
@@ -39,6 +39,7 @@ namespace Gw2Sharp.WebApi.V2
         private readonly IConnection connection;
         private readonly IGw2Client gw2Client;
         private readonly string? authorization;
+        private readonly string? token;
         private readonly string? locale;
         private readonly string userAgent;
 
@@ -59,7 +60,8 @@ namespace Gw2Sharp.WebApi.V2
             this.connection = connection;
             this.gw2Client = gw2Client;
 
-            this.authorization = endpointClient.IsAuthenticated ? $"{BEARER} {connection.AccessToken}" : null;
+            this.token = endpointClient.IsAuthenticated ? connection.AccessToken : null;
+            this.authorization = endpointClient.IsAuthenticated ? $"{BEARER} {this.token}" : null;
             this.locale = endpointClient.IsLocalized ? connection.LocaleString : null;
             this.userAgent = connection.UserAgent;
         }
@@ -133,12 +135,14 @@ namespace Gw2Sharp.WebApi.V2
 
         private IDictionary<string, string>? BuildQueryParams(IDictionary<string, string>? additionalQueryParams = null)
         {
-            if (this.queryParams.Count == 0)
-                return additionalQueryParams;
             var combinedQueryParams = new Dictionary<string, string>(this.queryParams);
+
+            if (!string.IsNullOrWhiteSpace(this.token))
+                combinedQueryParams["access_token"] = this.token;
+
             if (additionalQueryParams != null)
                 combinedQueryParams.AddRange(additionalQueryParams);
-            return combinedQueryParams;
+            return (combinedQueryParams.Count == 0) ? additionalQueryParams : combinedQueryParams;
         }
 
         private IDictionary<string, string> BuildHeaders()


### PR DESCRIPTION
Since 09th of November 2024 the API Header authentication is not working and many applications are down. This should fix the issue by using the GET Parameter alternative.

[Issue reference](https://en-forum.guildwars2.com/topic/153373-issues-with-the-guild-wars-2-api)
